### PR TITLE
Fix holdings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ print([t.data for t in statement])
 # ``data`` property
 
 # for retrieving the holdings of an account:
-holdings = f.get_holdings()
+holdings = f.get_holdings(accounts[0])
 # holdings contains a list of namedtuple values containing ISIN, name,
 # market_value, pieces, total_value and valuation_date as parsed from
 # the MT535 message.


### PR DESCRIPTION
I didn't had the chance to test it finally, but you will get this error if you want to execute the example:
```
f.get_holdings()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    f.get_holdings()
TypeError: get_holdings() missing 1 required positional argument: 'account'
```
According to this line https://github.com/raphaelm/python-fints/blob/master/fints/client.py#L168, this should fix the bug.