### PR TITLE
add "NIBC Direct" to list of tested banks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Banks tested:
 * Ing-Diba
 * CortalConsors, including access to holding accounts
 * DKB
+* NIBC Direct
 
 Usage
 -----


### PR DESCRIPTION
NIBC Direct works for me with the usage example:

    f = FinTS3PinTanClient(
        '51210700',
        'NIBCode',  # Service -> Online-Banking -> Alias
        'SECRET',
        'https://hbci11.fiducia.de/cgi-bin/hbciservlet'
    )

I noticed that the list of banks gets a bit messy so you might want to consider sorting it alphabetically. Also one of the main problems for me to get started is finding the right parameters (especially FinTS url, what user name, ...). Therefore I added it in the commit comment but I really like to have a central place where this is documented.