### PR TITLE
Implement HKTAN2

### DIFF
--- a/docs/tans.rst
+++ b/docs/tans.rst
@@ -144,6 +144,14 @@ You SHOULD use this facility together with the client and dialog state restorati
 Reference
 ---------
 
+.. autoclass:: fints.formals.TwoStepParameters2
+   :noindex:
+   :undoc-members:
+   :members:
+   :inherited-members:
+   :member-order: bysource
+   :exclude-members: is_unset, naive_parse, print_nested
+
 .. autoclass:: fints.formals.TwoStepParameters3
    :noindex:
    :undoc-members:

--- a/fints/client.py
+++ b/fints/client.py
@@ -25,7 +25,7 @@ from .security import (
     PinTanTwoStepAuthenticationMechanism,
 )
 from .segments.accounts import HISPA1, HKSPA1
-from .segments.auth import HIPINS1, HKTAB4, HKTAB5, HKTAN3, HKTAN5
+from .segments.auth import HIPINS1, HKTAB4, HKTAB5, HKTAN2, HKTAN3, HKTAN5
 from .segments.bank import HIBPA3, HIUPA4, HKKOM4
 from .segments.debit import (
     HKDBS1, HKDBS2, HKDMB1, HKDMC1, HKDME1, HKDME2,
@@ -960,6 +960,7 @@ class NeedTANResponse(NeedRetryResponse):
 #  which may require TANs for many more operations including dialog initialization.
 #  We do not currently support that.
 IMPLEMENTED_HKTAN_VERSIONS = {
+    2: HKTAN2,
     3: HKTAN3,
     5: HKTAN5,
 }
@@ -1047,7 +1048,7 @@ class FinTS3PinTanClient(FinTS3Client):
                 seg.account = account_
             raise NotImplementedError("TAN-Process 1 not implemented")
 
-        if tan_process in ('1', '3', '4') and \
+        if tan_process in ('1', '3', '4') and hasattr(tan_mechanism, 'supported_media_number') and \
             tan_mechanism.supported_media_number > 1 and \
             tan_mechanism.description_required == DescriptionRequired.MUST:
                 seg.tan_medium_name = self.selected_tan_medium

--- a/fints/segments/auth.py
+++ b/fints/segments/auth.py
@@ -32,6 +32,20 @@ class HKVVB3(FinTS3Segment):
     product_version = DataElementField(type='an', max_length=5, _d="Produktversion")
 
 
+class HKTAN2(FinTS3Segment):
+    """Zwei-Schritt-TAN-Einreichung, version 2
+
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Sicherheitsverfahren PIN/TAN"""
+    tan_process = DataElementField(type='code', length=1, _d="TAN-Prozess")
+    task_hash_value = DataElementField(type='bin', max_length=256, required=False, _d="Auftrags-Hashwert")
+    task_reference = DataElementField(type='an', max_length=35, required=False, _d="Auftragsreferenz")
+    tan_list_number = DataElementField(type='an', max_length=20, required=False, _d="TAN-Listennummer")
+    further_tan_follows = DataElementField(type='jn', length=1, required=False, _d="Weitere TAN folgt")
+    cancel_task = DataElementField(type='jn', length=1, required=False, _d="Auftrag stornieren")
+    challenge_class = DataElementField(type='num', max_length=2, required=False, _d="Challenge-Klasse")
+    parameter_challenge_class = DataElementGroupField(type=ParameterChallengeClass, required=False, _d="Parameter Challenge-Klasse")
+
+
 class HKTAN3(FinTS3Segment):
     """Zwei-Schritt-TAN-Einreichung, version 3
 
@@ -81,6 +95,19 @@ class HKTAN6(FinTS3Segment):
     parameter_challenge_class = DataElementGroupField(type=ParameterChallengeClass, required=False, _d="Parameter Challenge-Klasse")
     tan_medium_name = DataElementField(type='an', max_length=32, required=False, _d="Bezeichnung des TAN-Mediums")
     response_hhd_uc = DataElementGroupField(type=ResponseHHDUC, required=False, _d="Antwort HHD_UC")
+
+
+class HITAN2(FinTS3Segment):
+    """Zwei-Schritt-TAN-Einreichung Rückmeldung, version 2
+
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Sicherheitsverfahren PIN/TAN"""
+    tan_process = DataElementField(type='code', length=1, _d="TAN-Prozess")
+    task_hash_value = DataElementField(type='bin', max_length=256, required=False, _d="Auftrags-Hashwert")
+    task_reference = DataElementField(type='an', max_length=35, required=False, _d="Auftragsreferenz")
+    challenge = DataElementField(type='an', max_length=2048, required=False, _d="Challenge")
+    challenge_valid_until = DataElementGroupField(type=ChallengeValidUntil, required=False, _d="Gültigkeitsdatum und -uhrzeit für Challenge")
+    tan_list_number = DataElementField(type='an', max_length=20, required=False, _d="TAN-Listennummer")
+    ben = DataElementField(type='an', max_length=99, required=False, _d="BEN")
 
 
 class HITAN3(FinTS3Segment):


### PR DESCRIPTION
Fixes #46

Note on comdirect: They don't support the SEPA descriptor `pain.001.001.03` which simple_sepa_transfer selects by default, but instead want `pain.001.003.03`. Also: iTAN MUST be sent in the same dialogue as the transfer. Code that works:

````
from sepaxml import SepaTransfer
import getpass, datetime
config = {'name': 'Sender Name', 'IBAN': 'SEnderIBAN', 'BIC': 'SENDERBIC', 'batch': False, 'currency': 'EUR' }
sepa = SepaTransfer(config, schema='pain.001.003.03')
# amount is in eurocents
payment = {'name': 'Recipient Name', 'IBAN': 'REcipientIBAN', 'BIC': 'RECIPIENTBIC', 'amount': 100, "execution_date": datetime.date(1999, 1, 1), "description": "Transfer Purpose Text", "endtoend_id": None}
sepa.add_payment(payment)
xml = sepa.export().decode()

f = FinTS3PinTanClient(...)
with f:
  a = f.get_sepa_accounts[]
  r = f.sepa_transfer(a[0], xml, pain_descriptor="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03")
  t = getpass.getpass("Enter TAN "+r.challenge)
  f.send_tan(r, t)
````
