### PR TITLE
catch mt940-errors when getting transactions

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -502,6 +502,52 @@ class FinTS3Client:
 
         return statement
 
+    def get_filtered_transactions(self, account: SEPAAccount, start_date: datetime.date = None,
+                                  end_date: datetime.date = None):
+        """
+        Fetches the list of transactions of a bank account in a certain timeframe.
+        MT940-Errors are catched and the statements containing them returned as a seperate list.
+        :param account: SEPA
+        :param start_date: First day to fetch
+        :param end_date: Last day to fetch
+        :return: A tuple with a list of mt940.models.Transaction objects and another list with tuples of mt940-data
+        and error messages.
+        """
+
+        with self._get_dialog() as dialog:
+            hkkaz = self._find_highest_supported_command(HKKAZ5, HKKAZ6, HKKAZ7)
+
+            logger.info('Start fetching from {} to {}'.format(start_date, end_date))
+            responses = self._fetch_with_touchdowns(
+                dialog,
+                lambda touchdown: hkkaz(
+                    account=hkkaz._fields['account'].type.from_sepa_account(
+                        account),
+                    all_accounts=False,
+                    date_start=start_date,
+                    date_end=end_date,
+                    touchdown_point=touchdown,
+                ),
+                'HIKAZ'
+            )
+            logger.info('Fetching done.')
+
+        statement = []
+        with_error = []
+        for seg in responses:
+            # Note: MT940 messages are encoded in the S.W.I.F.T character set,
+            # which is a subset of ISO 8859. There are no character in it that
+            # differ between ISO 8859 variants, so we'll arbitrarily chose 8859-1.
+            try:
+                statement += mt940_to_array(seg.statement_booked.decode('iso-8859-1'))
+            except Exception as e:
+                with_error.append((seg.statement_booked.decode('iso-8859-1'), str(e)))
+
+        logger.debug('Statement: {}'.format(statement))
+        logger.debug('With error: {}'.format(with_error))
+
+        return statement, with_error
+
     def get_credit_card_transactions(self, account: SEPAAccount, credit_card_number: str, start_date: datetime.date = None, end_date: datetime.date = None):
         # FIXME Reverse engineered, probably wrong
         with self._get_dialog() as dialog:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,6 @@ def test_get_sepa_accounts(fints_client):
 
     assert accounts
 
-
 def test_get_information(fints_client):
     with fints_client:
         information = fints_client.get_information()
@@ -201,4 +200,14 @@ def test_get_transactions(fints_client):
         transactions = fints_client.get_transactions(accounts[0])
 
         assert len(transactions) == 3
+        assert transactions[0].data['amount'].amount == Decimal('182.34')
+
+def test_get_filtered_transactions(fints_client):
+    with fints_client:
+        accounts = fints_client.get_sepa_accounts()
+
+        transactions, errors = fints_client.get_filtered_transactions(accounts[0])
+
+        assert len(transactions) == 3
+        assert len(errors) == 0
         assert transactions[0].data['amount'].amount == Decimal('182.34')


### PR DESCRIPTION
Actually importing transactions is crashing if the MT940 sent by the bank is not correct. Depending on what was wrong in the MT940 you'll get another exception of the [mt940](https://github.com/WoLpH/mt940) library. I've submitted some examples of malformed MT940 in WoLpH/mt940#65

This PR adds an alternative for the `get_transactions()` function which catches those exceptions.
It returns the statements which were correct and could be parsed on the one hand and the malformed MT940-strings coupled with the thrown exception on the other hand.

With those caught errors it's possible to review the MT940 and rerun the parser later.
