### PR TITLE
Implement parsing a PNG QR code in HITAN3.challenge in CHLGUC member …

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from abc import ABCMeta, abstractmethod
+from base64 import b64decode
 from collections import OrderedDict
 from contextlib import contextmanager
 from decimal import Decimal
@@ -942,6 +943,10 @@ class NeedTANResponse(NeedRetryResponse):
             if l.isdigit():
                 self.challenge_hhduc = self.challenge[12:(12+int(l,10))]
                 self.challenge = self.challenge[(12+int(l,10)):]
+
+                if self.challenge_hhduc.startswith('iVBO'):
+                    self.challenge_matrix = ('image/png', b64decode(self.challenge_hhduc))
+                    self.challenge_hhduc = None
 
         if self.challenge.startswith('CHLGTEXT'):
             self.challenge = self.challenge[12:]


### PR DESCRIPTION
…(instead of flicker code data). Sparkasse does this for the new 913 "chipTAN-QR".

(I have not tested the code since apparently a Cronto "photoTAN" reader won't accept QR code images, but the PNG decodes and displays fine in browsers.)

It's slightly hacky to recognize PNG images by the base64 encoded first three bytes, but then so is parsing a plain text field in the first place.