### PR TITLE
Fix #65 -- Set Content-Type header on POST request

### DIFF
--- a/fints/connection.py
+++ b/fints/connection.py
@@ -24,6 +24,9 @@ class FinTSHTTPSConnection:
 
         r = requests.post(
             self.url, data=base64.b64encode(msg.render_bytes()),
+            headers={
+                'Content-Type': 'text/plain',
+            },
         )
 
         if r.status_code < 200 or r.status_code > 299:


### PR DESCRIPTION
Targobanks Tomcat configuration seems to require a Content-Type on the POSTed data. I don't think anywhere in the standard is anything relating to that, and it *is* correct HTTP, so shouldn't pose problems with other banks. Subsembly certainly does it this way.
Fixes #65