### PR TITLE
Fix and enhance get_transactions_xml()

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -543,7 +543,7 @@ class FinTS3Client:
                     date_start=start_date,
                     date_end=end_date,
                     touchdown_point=touchdown,
-                    supported_camt_messages=SupportedMessageTypes('urn:iso:std:iso:20022:tech:xsd:camt.052.001.02'),
+                    supported_camt_messages=SupportedMessageTypes(['urn:iso:std:iso:20022:tech:xsd:camt.052.001.02']),
                 ),
                 'HICAZ'
             )

--- a/fints/client.py
+++ b/fints/client.py
@@ -524,11 +524,13 @@ class FinTS3Client:
                              end_date: datetime.date = None) -> list:
         """
         Fetches the list of transactions of a bank account in a certain timeframe as camt.052.001.02 XML files.
+        Returns both booked and pending transactions.
 
         :param account: SEPA
         :param start_date: First day to fetch
         :param end_date: Last day to fetch
-        :return: A list of bytestrings containing XML documents
+        :return: Two lists of bytestrings containing XML documents, possibly empty: first one for booked transactions,
+            second for pending transactions
         """
 
         with self._get_dialog() as dialog:
@@ -549,10 +551,12 @@ class FinTS3Client:
             )
             logger.info('Fetching done.')
 
-        xml_streams = []
+        booked_streams = []
+        pending_streams = []
         for seg in responses:
-            xml_streams.append(seg.statement_booked)
-        return xml_streams
+            booked_streams.extend(seg.statement_booked.camt_statements)
+            pending_streams.append(seg.statement_pending)
+        return booked_streams, pending_streams
 
     def get_credit_card_transactions(self, account: SEPAAccount, credit_card_number: str, start_date: datetime.date = None, end_date: datetime.date = None):
         # FIXME Reverse engineered, probably wrong

--- a/fints/formals.py
+++ b/fints/formals.py
@@ -961,3 +961,10 @@ class SupportedMessageTypes(DataElementGroup):
     Source:  Messages - Multibankfähige Geschäftsvorfälle (SEPA) - C.2.3.1.1.1
     """
     expected_type = AlphanumericField(max_length=256, max_count=99, required=True, _d='Unterstützte camt-messages')
+
+
+class BookedCamtStatements1(DataElementGroup):
+    """Gebuchte camt-Umsätze
+
+    Source:  Messages - Multibankfähige Geschäftsvorfälle (SEPA)"""
+    camt_statements = DataElementField(type='bin', min_count=1, required=True, _d="camt-Umsätze gebucht")

--- a/fints/segments/statement.py
+++ b/fints/segments/statement.py
@@ -1,5 +1,6 @@
 from fints.fields import DataElementField, DataElementGroupField
-from fints.formals import KTI1, Account2, Account3, QueryCreditCardStatements2, SupportedMessageTypes
+from fints.formals import KTI1, Account2, Account3, QueryCreditCardStatements2, SupportedMessageTypes, \
+    BookedCamtStatements1
 
 from .base import FinTS3Segment, ParameterSegment
 
@@ -108,7 +109,5 @@ class HICAZ1(FinTS3Segment):
     Source: HBCI Homebanking-Computer-Interface, Schnittstellenspezifikation"""
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung Auftraggeber")
     camt_descriptor = DataElementField(type='an', _d="camt-Deskriptor")
-    # According to specification, statement_booked is a DEG with one binary XML *per day*. However, banks apparently
-    # send just one XML instead.
-    statement_booked = DataElementField(type='bin', _d="Gebuchte Umsätze")
+    statement_booked = DataElementGroupField(type=BookedCamtStatements1, _d="Gebuchte Umsätze")
     statement_pending = DataElementField(type='bin', required=False, _d="Nicht gebuchte Umsätze")


### PR DESCRIPTION
Make `get_transactions_xml()` work with Sparkasse.
Two parts: First one is fixing sent and received messages, second one is changing the return value to include both booked and pending statements.