### PR TITLE
Implement dikku2

### DIFF
--- a/fints/formals.py
+++ b/fints/formals.py
@@ -659,20 +659,19 @@ class CreditCardTransaction1(DataElementGroup):
 
     Source: Reverse engineered"""
     credit_card_number = DataElementField(type='an', _d="Kreditkartennummer")
-    _date_1 = DataElementField(type='dat', _d="Datum")  # FIXME booked vs. valued date?
-    _date_2 = DataElementField(type='dat', _d="Datum")
-    _unknown_1 = DataElementField(type='an')
-    amount = DataElementField(type='wrt', _d="Wert")
+    receipt_date = DataElementField(type='dat', _d="Belegdatum")
+    booking_date = DataElementField(type='dat', _d="Buchungsatum")
+    value_date = DataElementField(type='dat', _d="Wertstellungsdatum")
+    original_amount = DataElementField(type='wrt', _d="Original-Wert")
     currency = DataElementField(type='cur', _d="Währung")
     credit_debit = CodeField(enum=CreditDebit2, length=1, _d="Soll-Haben-Kennzeichen")
-    _unknown_2 = DataElementField(type='an')
-    _amount_2 = DataElementField(type='wrt', _d="Wert")  # FIXME Maybe own vs. other currency?
-    _currency_2 = DataElementField(type='cur', _d="Währung")
-    _credit_debit_2 = CodeField(enum=CreditDebit2, length=1, _d="Soll-Haben-Kennzeichen")
-    memo = DataElementField(type='an', _d="Betreff")
-    _unknown_3 = DataElementField(type='an', count=8)
-    _unknown_4 = DataElementField(type='jn')
-    _unknown_5 = DataElementField(type='an')
+    exchange_rate = DataElementField(type='float', _d="Umrechnungskurs")
+    booked_amount = DataElementField(type='wrt', _d="Gebuchter Wert")
+    booked_currency = DataElementField(type='cur', _d="Gebuchte Währung")
+    booked_credit_debit = CodeField(enum=CreditDebit2, length=1, _d="Gebuchtes Soll-Haben-Kennzeichen")
+    memo = DataElementField(type='an', _d="Buchungstext", count=9)
+    settled = DataElementField(type='jn')
+    booking_reference = DataElementField(type='an', _d="Buchungsreferenz")
 
 
 

--- a/fints/formals.py
+++ b/fints/formals.py
@@ -654,6 +654,28 @@ class Balance2(DataElementGroup):
         )
 
 
+class CreditCardTransaction1(DataElementGroup):
+    """Kreditkartenumsatz
+
+    Source: Reverse engineered"""
+    credit_card_number = DataElementField(type='an', _d="Kreditkartennummer")
+    _date_1 = DataElementField(type='dat', _d="Datum")  # FIXME booked vs. valued date?
+    _date_2 = DataElementField(type='dat', _d="Datum")
+    _unknown_1 = DataElementField(type='an')
+    amount = DataElementField(type='wrt', _d="Wert")
+    currency = DataElementField(type='cur', _d="Währung")
+    credit_debit = CodeField(enum=CreditDebit2, length=1, _d="Soll-Haben-Kennzeichen")
+    _unknown_2 = DataElementField(type='an')
+    _amount_2 = DataElementField(type='wrt', _d="Wert")  # FIXME Maybe own vs. other currency?
+    _currency_2 = DataElementField(type='cur', _d="Währung")
+    _credit_debit_2 = CodeField(enum=CreditDebit2, length=1, _d="Soll-Haben-Kennzeichen")
+    memo = DataElementField(type='an', _d="Betreff")
+    _unknown_3 = DataElementField(type='an', count=8)
+    _unknown_4 = DataElementField(type='jn')
+    _unknown_5 = DataElementField(type='an')
+
+
+
 class Timestamp1(DataElementGroup):
     """Zeitstempel
 

--- a/fints/segments/statement.py
+++ b/fints/segments/statement.py
@@ -1,5 +1,6 @@
 from fints.fields import DataElementField, DataElementGroupField
-from fints.formals import KTI1, Account2, Account3, QueryCreditCardStatements2, SupportedMessageTypes
+from fints.formals import KTI1, Account2, Account3, QueryCreditCardStatements2, SupportedMessageTypes, Balance1,\
+    CreditCardTransaction1
 
 from .base import FinTS3Segment, ParameterSegment
 
@@ -81,6 +82,13 @@ class DIKKU2(FinTS3Segment):
     """Kreditkartenumsätze rückmelden, version 2
 
     Source: Reverse engineered"""
+    credit_card_number = DataElementField(type='an', _d="Kreditkartennummer")
+    _unknown_1 = DataElementField(type='an')
+    balance = DataElementGroupField(type=Balance1, _d="Saldo")
+    _unknown_2 = DataElementField(type='an')
+    _unknown_3 = DataElementField(type='an')
+    transactions = DataElementGroupField(type=CreditCardTransaction1, _d="Kreditkartenumsatz", min_count=1, required=False)
+
 
 class DIKKUS2(ParameterSegment):
     """Kreditkartenumsätze anfordern Parameter, version 2


### PR DESCRIPTION
This implements DKKKU/DIKKU for fetching credit card transactions from f.e. comdirect.

I'm not quite happy with the API yet: The bank response includes additional data (card number and balance) but also a list of transactions for which a touchdown_point may be in use. How do we want to return that? Concatenate the transaction lists and return the other information separately (secondary question: from the first response or from the last response?)? Create a special container object? Just discard the additional information?
(Currently the function just returns a list of DIKKU2 objects)