### PR TITLE
Loosen sepaxml version bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
 
     keywords='hbci banking fints',
     install_requires=[
-        'requests', 'mt-940', 'sepaxml==2.0.*', 'bleach',
+        'bleach',
+        'mt-940',
+        'requests',
+        'sepaxml~=2.0',
     ],
 
     packages=find_packages(include=['fints', 'fints.*']),


### PR DESCRIPTION
sepaxml released 2.1.0, your tests still pass using the new version. If they're strictly adhering to SemVer, then this release shouldn't break anything.

~=2.0 is rough equivalent to '>=2.0,<3' or '>=2.0,2.*'