### PR TITLE
PSD2 support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,9 @@ Library user documentation content
    transfers
    debits
    tested
+   upgrading_2_3
    upgrading_1_2
+   trouble
 
 
 Library developer documentation content

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -24,12 +24,28 @@ of your bank. Logging in with a signature file or chip card is currently not sup
         product_id='Your product ID'
     )
 
-
-You can then execute commands using the client instance:
+Since the implementation of PSD2, you will in almost all cases need to be ready to deal with TANs. For a quick start,
+we included a minimal command-line utility to help choose a TAN method:
 
 .. code-block:: python
 
-    accounts = f.get_sepa_accounts()
+    from fints.utils import minimal_interactive_cli_bootstrap
+    minimal_interactive_cli_bootstrap(f)
+
+You can then open up a real communication dialog to the bank with a ``with`` statement and issue commands:
+commands using the client instance:
+
+.. code-block:: python
+
+    with f:
+        # Since PSD2, a TAN might be needed for dialog initialization. Let's check if there is one required
+        if f.init_tan_response:
+            print("A TAN is required", f.init_tan_response.challenge)
+            tan = input('Please enter TAN:')
+            f.send_tan(f.init_tan_response, tan)
+
+        # Fetch accounts
+        accounts = f.get_sepa_accounts()
 
 Go on to the next pages to find out what commands are supported!
 

--- a/docs/reading.rst
+++ b/docs/reading.rst
@@ -1,6 +1,11 @@
 Reading operations
 ==================
 
+.. note::
+
+   Starting from version 3, **all of the methods on this page** can return a ``NeedTANResponse`` instead of actual
+   data if your bank requires a TAN. You should then enter a TAN, read our chapter :ref:`tans` to find out more.
+
 Fetching your bank accounts
 ---------------------------
 

--- a/docs/tans.rst
+++ b/docs/tans.rst
@@ -30,6 +30,9 @@ If the ``description_required`` attribute for the TAN mechanism is :attr:`~fints
 you will need to get a list of TAN media with :func:`~fints.client.FinTS3PinTanClient.get_tan_media` and select the
 appropriate one with :func:`~fints.client.FinTS3PinTanClient.set_tan_medium`.
 
+Have a look at the source code of :func:`~fints.utils.minimal_interactive_cli_bootstrap` for an example on how to
+ask the user for these properties.
+
 You may not change the active TAN mechanism or TAN medium within a standing dialog (see :ref:`client-dialog-state`).
 
 The selection of the active TAN mechanism/medium is stored with the persistent client data (see :ref:`client-state`).

--- a/docs/tested.rst
+++ b/docs/tested.rst
@@ -1,28 +1,25 @@
 Tested banks
 ============
 
-The following banks have been tested with version 2.x of this library:
+The following banks have been tested with version 3.x of this library:
 
 ======================================== ============ ======== ======== ======
 Bank                                     Transactions Holdings Transfer Debits
                                          and Balance
 ======================================== ============ ======== ======== ======
-GLS Bank eG                              Yes                   Yes      Yes
 Postbank                                 Yes
-Triodos Bank                             Yes                   Yes
-Volksbank Darmstadt-Südhessen            Yes                   Yes
-Deutsche Skatbank                        Yes                   Yes
 BBBank eG                                Yes                   Yes
-MLP Banking AG                           Yes
+Sparkasse Heidelberg                     Yes
 ======================================== ============ ======== ======== ======
 
 Tested security functions
 -------------------------
 
+* ``921`` "pushTAN"
+* ``930`` "mobile TAN"
 * ``942`` "mobile TAN"
 * ``962`` "Smart-TAN plus manuell"
 * ``972`` "Smart-TAN plus optisch"
-
 
 
 Legacy results
@@ -48,3 +45,18 @@ Volksbank (Fiducia)                      Yes
 Wüstenrot                                Yes
 1822direkt                               Yes           Yes
 ======================================== ============  ======== ======== ======
+
+The following banks have been tested with the old version 2.x of this library:
+
+======================================== ============ ======== ======== ======
+Bank                                     Transactions Holdings Transfer Debits
+                                         and Balance
+======================================== ============ ======== ======== ======
+GLS Bank eG                              Yes                   Yes      Yes
+Postbank                                 Yes
+Triodos Bank                             Yes                   Yes
+Volksbank Darmstadt-Südhessen            Yes                   Yes
+Deutsche Skatbank                        Yes                   Yes
+BBBank eG                                Yes                   Yes
+MLP Banking AG                           Yes
+======================================== ============ ======== ======== ======

--- a/docs/trouble.rst
+++ b/docs/trouble.rst
@@ -1,0 +1,173 @@
+Troubleshooting and bug reporting
+=================================
+
+The FinTS specification is long and complicated and in many parts leaves things open to interpretation -- or sometimes
+implementors interpret things differently even though they're not really open to interpretation. This is valid for us,
+but also for the banks. Making the library work with many diffrent banks is hard, and often impossible without access
+to a test account. Therefore, we ask you for patience when reporting issues with different banks -- and you need to be
+ready that we might not be able to help you because we do not have the time or bank account required to dig deeper.
+
+Therefore, if you run into trouble with this library, you first need to ask yourself a very important question: **Is it
+me or the library?** To answer this question for most cases, we have attached a script below, that we ask you to use
+to try the affected feature of the library in a well-documented way. Apart from changing the arguments (i.e. your bank's
+parameters and your credentials) at the top, we ask you **not to make any modifications**. Pasting this bit by bit into
+a Jupyter notebook **is a modification**. If your issue does not include information as to whether the script below works
+or does not work for your bank, **we will close your issue without further comment.**
+
+**If the script below does not work for you**, there is probably a compatibility issue between this library and your
+bank. Feel free to open an issue, but make sure the issue title includes the name of the bank and the text includes
+what operations specifically fail.
+
+**If the script below does work for you**, there is probably something wrong with your usage of the library or our
+documentation. Feel free to open an issue, but **include full working example code** that is necessary to reproduce
+the problem.
+
+.. note:: Before posting anything on GitHub, make sure it does not contain your username, PIN, IBAN, or similarly sensitive data.
+
+.. code-block:: python
+
+    import datetime
+    import getpass
+    import logging
+    import sys
+    from decimal import Decimal
+
+    from fints.client import FinTS3PinTanClient, NeedTANResponse, FinTSUnsupportedOperation
+    from fints.hhd.flicker import terminal_flicker_unix
+    from fints.utils import minimal_interactive_cli_bootstrap
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    client_args = (
+        'REPLACEME',  # BLZ
+        'REPLACEME',  # USER
+        getpass.getpass('PIN: '),
+        'REPLACEME'  # ENDPOINT
+    )
+
+    f = FinTS3PinTanClient(*client_args)
+    minimal_interactive_cli_bootstrap(f)
+
+
+    def ask_for_tan(response):
+        print("A TAN is required")
+        print(response.challenge)
+        if getattr(response, 'challenge_hhduc', None):
+            try:
+                terminal_flicker_unix(response.challenge_hhduc)
+            except KeyboardInterrupt:
+                pass
+        tan = input('Please enter TAN:')
+        return f.send_tan(response, tan)
+
+
+    # Open the actual dialog
+    with f:
+        # Since PSD2, a TAN might be needed for dialog initialization. Let's check if there is one required
+        if f.init_tan_response:
+            ask_for_tan(f.init_tan_response)
+
+        # Fetch accounts
+        accounts = f.get_sepa_accounts()
+        if isinstance(accounts, NeedTANResponse):
+            accounts = ask_for_tan(accounts)
+        if len(accounts) == 1:
+            account = accounts[0]
+        else:
+            print("Multiple accounts available, choose one")
+            for i, mm in enumerate(accounts):
+                print(i, mm.iban)
+            choice = input("Choice: ").strip()
+            account = accounts[int(choice)]
+
+        # Test pausing and resuming the dialog
+        dialog_data = f.pause_dialog()
+
+    client_data = f.deconstruct(including_private=True)
+
+    f = FinTS3PinTanClient(*client_args, from_data=client_data)
+    with f.resume_dialog(dialog_data):
+        while True:
+            operations = [
+                "End dialog",
+                "Fetch transactions of the last 30 days",
+                "Fetch transactions of the last 120 days",
+                "Fetch transactions XML of the last 30 days",
+                "Fetch transactions XML of the last 120 days",
+                "Fetch information",
+                "Fetch balance",
+                "Fetch holdings",
+                "Fetch scheduled debits",
+                "Fetch status protocol",
+                "Make a simple transfer"
+            ]
+
+            print("Choose an operation")
+            for i, o in enumerate(operations):
+                print(i, o)
+            choice = int(input("Choice: ").strip())
+            try:
+                if choice == 0:
+                    break
+                elif choice == 1:
+                    res = f.get_transactions(account, datetime.date.today() - datetime.timedelta(days=30),
+                                             datetime.date.today())
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print("Found", len(res), "transactions")
+                elif choice == 2:
+                    res = f.get_transactions(account, datetime.date.today() - datetime.timedelta(days=120),
+                                             datetime.date.today())
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print("Found", len(res), "transactions")
+                elif choice == 3:
+                    res = f.get_transactions_xml(account, datetime.date.today() - datetime.timedelta(days=30),
+                                                 datetime.date.today())
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print("Found", len(res[0]) + len(res[1]), "XML documents")
+                elif choice == 4:
+                    res = f.get_transactions_xml(account, datetime.date.today() - datetime.timedelta(days=120),
+                                                 datetime.date.today())
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print("Found", len(res[0]) + len(res[1]), "XML documents")
+                elif choice == 5:
+                    print(f.get_information())
+                elif choice == 6:
+                    res = f.get_balance(account)
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print(res)
+                elif choice == 7:
+                    res = f.get_holdings(account)
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print(res)
+                elif choice == 8:
+                    res = f.get_scheduled_debits(account)
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print(res)
+                elif choice == 9:
+                    res = f.get_status_protocol()
+                    while isinstance(res, NeedTANResponse):
+                        res = ask_for_tan(res)
+                    print(res)
+                elif choice == 10:
+                    res = f.simple_sepa_transfer(
+                        account=accounts[0],
+                        iban=input('Target IBAN:'),
+                        bic=input('Target BIC:'),
+                        amount=Decimal(input('Amount:')),
+                        recipient_name=input('Recipient name:'),
+                        account_name=input('Your name:'),
+                        reason=input('Reason:'),
+                        endtoend_id='NOTPROVIDED',
+                    )
+
+                    if isinstance(res, NeedTANResponse):
+                        ask_for_tan(res)
+            except FinTSUnsupportedOperation as e:
+                print("This operation is not supported by this bank:", e)

--- a/docs/upgrading_1_2.rst
+++ b/docs/upgrading_1_2.rst
@@ -1,5 +1,5 @@
-Upgrading from python-fints 1.x
-===============================
+Upgrading from python-fints 1.x to 2.x
+======================================
 
 This library has seen a major rewrite in version 2.0 and the API has changed in a lot of places. These are the most
 important changes to know:

--- a/docs/upgrading_2_3.rst
+++ b/docs/upgrading_2_3.rst
@@ -1,0 +1,15 @@
+Upgrading from python-fints 2.x to 3.x
+======================================
+
+Release 3.0 of this library was made to adjust to changes made by the banks as part of their PSD2 implementation
+in 2019. Here's what you should know when porting your code:
+
+* A TAN can now be required for dialog initialization. In this case, ``client.init_tan_response`` will contain a
+  ``NeedTANResponse``.
+
+* Basically every method of the client class can now return a ``NeedTANResponse``, so you should always expect this
+  case and handle it gracefully.
+
+* Since everything can require a TAN, everything requires a standing dialog. Issuing interactive commands outside of a
+  ``with client:`` statement is now deprecated. It still might work in very few cases, so we didn't disable it, but we
+  do not support it any longer. This affects you mostly when you work with this on a Python REPL or e.g. in a Notebook.

--- a/fints/client.py
+++ b/fints/client.py
@@ -1120,6 +1120,7 @@ class FinTS3PinTanClient(FinTS3Client):
 
     def fetch_tan_mechanisms(self):
         self.set_tan_mechanism('999')
+        self._ensure_system_id()
         with self._new_dialog():
             return self.get_current_tan_mechanism()
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -153,7 +153,6 @@ class TransactionResponse:
 
 class FinTSClientMode(Enum):
     OFFLINE = 'offline'
-    NONINTERACTIVE = 'noninteractive'
     INTERACTIVE = 'interactive'
 
 
@@ -162,7 +161,7 @@ class FinTS3Client:
                  bank_identifier, user_id, customer_id=None,
                  from_data: bytes=None,
                  product_id=None, product_version=version[:5],
-                 mode=FinTSClientMode.NONINTERACTIVE):
+                 mode=FinTSClientMode.INTERACTIVE):
         self.accounts = []
         if isinstance(bank_identifier, BankIdentifier):
             self.bank_identifier = bank_identifier

--- a/fints/client.py
+++ b/fints/client.py
@@ -603,6 +603,10 @@ class FinTS3Client:
 
         return responses
 
+    def _get_balance(self, command_seg, response):
+        for resp in response.response_segments(command_seg, 'HISAL'):
+            return resp.balance_booked.as_mt940_Balance()
+
     def get_balance(self, account: SEPAAccount):
         """
         Fetches an accounts current balance.
@@ -619,10 +623,8 @@ class FinTS3Client:
                 all_accounts=False,
             )
 
-            response = dialog.send(seg)
-
-            for resp in response.response_segments(seg, 'HISAL'):
-                return resp.balance_booked.as_mt940_Balance()
+            response = self._send_with_possible_retry(dialog, seg, self._get_balance)
+            return response
 
     def get_holdings(self, account: SEPAAccount):
         """

--- a/fints/client.py
+++ b/fints/client.py
@@ -152,7 +152,10 @@ class TransactionResponse:
 
 
 class FinTS3Client:
-    def __init__(self, bank_identifier, user_id, customer_id=None, from_data: bytes=None, product_id=None):
+    def __init__(self,
+                 bank_identifier, user_id, customer_id=None,
+                 from_data: bytes=None,
+                 product_id=None, product_version=version[:5]):
         self.accounts = []
         if isinstance(bank_identifier, BankIdentifier):
             self.bank_identifier = bank_identifier
@@ -164,7 +167,7 @@ class FinTS3Client:
         if not product_id:
             logger.warn('You should register your program with the ZKA and pass your own product_id as a parameter.')
             product_id = 'DC333D745719C4BD6A6F9DB6A'
-        
+
         self.user_id = user_id
         self.customer_id = customer_id or user_id
         self.bpd_version = 0
@@ -174,7 +177,7 @@ class FinTS3Client:
         self.upa = None
         self.upd = SegmentSequence()
         self.product_name = product_id
-        self.product_version = version[:5]
+        self.product_version = product_version
         self.response_callbacks = []
         self._standing_dialog = None
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -1342,14 +1342,15 @@ class FinTS3PinTanClient(FinTS3Client):
             hktab = self._find_highest_supported_command(HKTAB4, HKTAB5)
 
             seg = hktab(
-                tan_media_type = media_type,
-                tan_media_class = str(media_class),
+                tan_media_type=media_type,
+                tan_media_class=str(media_class),
             )
-            tan_seg = self._get_tan_segment(seg, '4')
+            # The specification says we should send a dummy HKTAN object but apparently it seems to do more harm than
+            # good.
 
             try:
                 self._bootstrap_mode = True
-                response = dialog.send(seg, tan_seg)
+                response = dialog.send(seg)
             finally:
                 self._bootstrap_mode = False
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -155,7 +155,8 @@ class FinTS3Client:
     def __init__(self,
                  bank_identifier, user_id, customer_id=None,
                  from_data: bytes=None,
-                 product_id=None, product_version=version[:5]):
+                 product_id=None, product_version=version[:5],
+                 stay_offline=False):
         self.accounts = []
         if isinstance(bank_identifier, BankIdentifier):
             self.bank_identifier = bank_identifier
@@ -179,6 +180,7 @@ class FinTS3Client:
         self.product_name = product_id
         self.product_version = product_version
         self.response_callbacks = []
+        self.stay_offline = stay_offline
         self._standing_dialog = None
 
         if from_data:

--- a/fints/client.py
+++ b/fints/client.py
@@ -645,6 +645,9 @@ class FinTS3Client:
                 'HIWPD'
             )
 
+        if isinstance(responses, NeedTANResponse):
+            return responses
+
         holdings = []
         for resp in responses:
             if type(resp.holdings) == bytes:

--- a/fints/client.py
+++ b/fints/client.py
@@ -1139,6 +1139,7 @@ class FinTS3PinTanClient(FinTS3Client):
             response = dialog.init(
                 HKSYN3(SynchronizationMode.NEW_SYSTEM_ID),
             )
+            self.process_response_message(dialog, response, internal_send=True)
             seg = response.find_segment_first(HISYN4)
             if not seg:
                 raise ValueError('Could not find system_id')
@@ -1281,7 +1282,7 @@ class FinTS3PinTanClient(FinTS3Client):
             raise FinTSClientError("Error during dialog initialization, could not fetch BPD. Please check that you "
                                    "passed the correct bank identifier to the HBCI URL of the correct bank.")
 
-        if ((not dialog.open and response.code.startswith('9')) or response.code in ('9340', '9910', '9930', '9931', '9942')) and not self._bootstrap_mode:
+        if ((not dialog.open and response.code.startswith('9')) and not self._bootstrap_mode)  or response.code in ('9340', '9910', '9930', '9931', '9942'):
             # Assume all 9xxx errors in a not-yet-open dialog refer to the PIN or authentication
             # During a dialog also listen for the following codes which may explicitly indicate an
             # incorrect pin: 9340, 9910, 9930, 9931, 9942

--- a/fints/client.py
+++ b/fints/client.py
@@ -1121,6 +1121,9 @@ class FinTS3PinTanClient(FinTS3Client):
     def fetch_tan_mechanisms(self):
         self.set_tan_mechanism('999')
         self._ensure_system_id()
+        if self.get_current_tan_mechanism():
+            # We already got a reply through _ensure_system_id
+            return self.get_current_tan_mechanism()
         with self._new_dialog():
             return self.get_current_tan_mechanism()
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -1256,6 +1256,9 @@ class FinTS3PinTanClient(FinTS3Client):
                 self.pin.block()
             raise FinTSClientTemporaryAuthError("Account is temporarily locked.")
 
+        if response.code == '9075':
+            raise FinTSSCARequiredError("This operation requires strong customer authentication.")
+
     def get_tan_mechanisms(self):
         """
         Get the available TAN mechanisms.

--- a/fints/client.py
+++ b/fints/client.py
@@ -26,7 +26,7 @@ from .security import (
     PinTanTwoStepAuthenticationMechanism,
 )
 from .segments.accounts import HISPA1, HKSPA1
-from .segments.auth import HIPINS1, HKTAB4, HKTAB5, HKTAN2, HKTAN3, HKTAN5
+from .segments.auth import HIPINS1, HKTAB4, HKTAB5, HKTAN2, HKTAN3, HKTAN5, HKTAN6
 from .segments.bank import HIBPA3, HIUPA4, HKKOM4
 from .segments.debit import (
     HKDBS1, HKDBS2, HKDMB1, HKDMC1, HKDME1, HKDME2,
@@ -1061,6 +1061,7 @@ IMPLEMENTED_HKTAN_VERSIONS = {
     2: HKTAN2,
     3: HKTAN3,
     5: HKTAN5,
+    6: HKTAN6,
 }
 
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -473,13 +473,14 @@ class FinTS3Client:
                 logger.info('Fetching more results ({})...'.format(touchdown_counter))
 
             touchdown_counter += 1
-            while touchdown:
+            if touchdown:
                 seg = segment_factory(touchdown)
-                self._send_with_possible_retry(dialog, seg, _continue)
+                return self._send_with_possible_retry(dialog, seg, _continue)
+            else:
+                return responses
 
         seg = segment_factory(touchdown)
-        self._send_with_possible_retry(dialog, seg, _continue)
-        return responses
+        return self._send_with_possible_retry(dialog, seg, _continue)
 
     def _find_highest_supported_command(self, *segment_classes, **kwargs):
         """Search the BPD for the highest supported version of a segment."""

--- a/fints/client.py
+++ b/fints/client.py
@@ -1184,7 +1184,7 @@ class FinTS3PinTanClient(FinTS3Client):
 
         if tan_process in ('1', '3', '4') and self.is_tan_media_required():
             if self.selected_tan_medium:
-                seg.tan_medium_name = self.selected_tan_medium.tan_medium_name
+                seg.tan_medium_name = self.selected_tan_medium
             else:
                 seg.tan_medium_name = 'DUMMY'
 
@@ -1333,7 +1333,7 @@ class FinTS3PinTanClient(FinTS3Client):
     def set_tan_medium(self, tan_medium):
         if self._standing_dialog:
             raise Exception("Cannot change TAN medium with a standing dialog")
-        self.selected_tan_medium = tan_medium
+        self.selected_tan_medium = tan_medium.tan_medium_name
 
     def get_tan_media(self, media_type = TANMediaType2.ALL, media_class = TANMediaClass4.ALL):
         """Get information about TAN lists/generators.

--- a/fints/client.py
+++ b/fints/client.py
@@ -1135,7 +1135,6 @@ class FinTS3PinTanClient(FinTS3Client):
     def _get_tan_segment(self, orig_seg, tan_process, tan_seg=None):
         tan_mechanism = self.get_tan_mechanisms()[self.get_current_tan_mechanism()]
 
-        hitans = self.bpd.find_segment_first('HITANS', tan_mechanism.VERSION)
         hktan = IMPLEMENTED_HKTAN_VERSIONS.get(tan_mechanism.VERSION)
 
         seg = hktan(tan_process=tan_process)

--- a/fints/client.py
+++ b/fints/client.py
@@ -1131,11 +1131,10 @@ class FinTS3PinTanClient(FinTS3Client):
             response = dialog.init(
                 HKSYN3(SynchronizationMode.NEW_SYSTEM_ID),
             )
-
-        seg = response.find_segment_first(HISYN4)
-        if not seg:
-            raise ValueError('Could not find system_id')
-        self.system_id = seg.system_id
+            seg = response.find_segment_first(HISYN4)
+            if not seg:
+                raise ValueError('Could not find system_id')
+            self.system_id = seg.system_id
 
     def _set_data_v1(self, data):
         super()._set_data_v1(data)

--- a/fints/client.py
+++ b/fints/client.py
@@ -165,7 +165,7 @@ class FinTS3Client:
             raise TypeError("bank_identifier must be BankIdentifier or str (BLZ)")
         self.system_id = SYSTEM_ID_UNASSIGNED
         if not product_id:
-            logger.warn('You should register your program with the ZKA and pass your own product_id as a parameter.')
+            logger.warning('You should register your program with the ZKA and pass your own product_id as a parameter.')
             product_id = 'DC333D745719C4BD6A6F9DB6A'
 
         self.user_id = user_id

--- a/fints/client.py
+++ b/fints/client.py
@@ -151,12 +151,18 @@ class TransactionResponse:
         return "<{o.__class__.__name__}(status={o.status!r}, responses={o.responses!r}, data={o.data!r})>".format(o=self)
 
 
+class FinTSClientMode(Enum):
+    OFFLINE = 'offline'
+    NONINTERACTIVE = 'noninteractive'
+    INTERACTIVE = 'interactive'
+
+
 class FinTS3Client:
     def __init__(self,
                  bank_identifier, user_id, customer_id=None,
                  from_data: bytes=None,
                  product_id=None, product_version=version[:5],
-                 stay_offline=False):
+                 mode=FinTSClientMode.NONINTERACTIVE):
         self.accounts = []
         if isinstance(bank_identifier, BankIdentifier):
             self.bank_identifier = bank_identifier
@@ -180,7 +186,7 @@ class FinTS3Client:
         self.product_name = product_id
         self.product_version = product_version
         self.response_callbacks = []
-        self.stay_offline = stay_offline
+        self.mode = mode
         self._standing_dialog = None
 
         if from_data:

--- a/fints/dialog.py
+++ b/fints/dialog.py
@@ -48,6 +48,11 @@ class FinTSDialog:
         if self.paused:
             raise FinTSDialogStateError("Cannot init() a paused dialog")
 
+        if self.client.stay_offline:
+            raise FinTSDialogOfflineError("Cannot open a dialog with stay_offline=True. "
+                                          "This is a control flow error, no online functionality "
+                                          "should have been attempted with this FinTSClient object.")
+
         if self.need_init and not self.open:
             segments = [
                 HKIDN2(

--- a/fints/dialog.py
+++ b/fints/dialog.py
@@ -48,7 +48,7 @@ class FinTSDialog:
         if self.paused:
             raise FinTSDialogStateError("Cannot init() a paused dialog")
 
-        from fints.client import FinTSClientMode
+        from fints.client import FinTSClientMode, NeedTANResponse
         if self.client.mode == FinTSClientMode.OFFLINE:
             raise FinTSDialogOfflineError("Cannot open a dialog with mode=FinTSClientMode.OFFLINE. "
                                           "This is a control flow error, no online functionality "
@@ -70,14 +70,29 @@ class FinTSDialog:
                     self.client.product_version
                 ),
             ]
+
             if self.client.mode == FinTSClientMode.INTERACTIVE and self.client.get_tan_mechanisms():
-                segments.append(self.client._get_tan_segment(segments[0], '4'))
+                tan_seg = self.client._get_tan_segment(segments[0], '4')
+                segments.append(tan_seg)
+            else:
+                tan_seg = None
+
             for s in extra_segments:
                 segments.append(s)
 
             try:
                 self.open = True
                 retval = self.send(*segments, internal_send=True)
+
+                if tan_seg:
+                    for resp in retval.responses(tan_seg):
+                        if resp.code == '0030':
+                            self.client.init_tan_response = NeedTANResponse(
+                                None,
+                                retval.find_segment_first('HITAN'),
+                                '_continue_dialog_initialization',
+                                self.client.is_challenge_structured()
+                            )
                 self.need_init = False
                 return retval
             except Exception as e:

--- a/fints/dialog.py
+++ b/fints/dialog.py
@@ -48,8 +48,9 @@ class FinTSDialog:
         if self.paused:
             raise FinTSDialogStateError("Cannot init() a paused dialog")
 
-        if self.client.stay_offline:
-            raise FinTSDialogOfflineError("Cannot open a dialog with stay_offline=True. "
+        from fints.client import FinTSClientMode
+        if self.client.mode == FinTSClientMode.OFFLINE:
+            raise FinTSDialogOfflineError("Cannot open a dialog with mode=FinTSClientMode.OFFLINE. "
                                           "This is a control flow error, no online functionality "
                                           "should have been attempted with this FinTSClient object.")
 

--- a/fints/dialog.py
+++ b/fints/dialog.py
@@ -68,8 +68,10 @@ class FinTSDialog:
                     Language2.DE,
                     self.client.product_name,
                     self.client.product_version
-                )
+                ),
             ]
+            if self.client.mode == FinTSClientMode.INTERACTIVE and self.client.get_tan_mechanisms():
+                segments.append(self.client._get_tan_segment(segments[0], '4'))
             for s in extra_segments:
                 segments.append(s)
 

--- a/fints/exceptions.py
+++ b/fints/exceptions.py
@@ -22,6 +22,10 @@ class FinTSDialogStateError(FinTSDialogError):
     pass
 
 
+class FinTSDialogOfflineError(FinTSDialogError):
+    pass
+
+
 class FinTSDialogInitError(FinTSDialogError):
     pass
 

--- a/fints/exceptions.py
+++ b/fints/exceptions.py
@@ -14,6 +14,10 @@ class FinTSClientTemporaryAuthError(FinTSClientError):
     pass
 
 
+class FinTSSCARequiredError(FinTSClientError):
+    pass
+
+
 class FinTSDialogError(FinTSError):
     pass
 

--- a/fints/utils.py
+++ b/fints/utils.py
@@ -297,3 +297,36 @@ class RepresentableEnum(Enum):
 
     def __str__(self):
         return self.value
+
+
+def minimal_interactive_cli_bootstrap(client):
+    """
+    This is something you usually implement yourself to ask your user in a nice, user-friendly way about these things.
+    This is mainly included to keep examples in the documentation simple and allow you to get started quickly.
+    """
+    # Fetch available TAN mechanisms by the bank, if we don't know it already. If the client was created with cached data,
+    # the function is already set.
+    if not client.get_current_tan_mechanism():
+        client.fetch_tan_mechanisms()
+        mechanisms = list(client.get_tan_mechanisms().items())
+        if len(mechanisms) > 1:
+            print("Multiple tan mechanisms available. Which one do you prefer?")
+            for i, m in enumerate(mechanisms):
+                print(i, "Function {p.security_function}: {p.name}".format(p=m[1]))
+            choice = input("Choice: ").strip()
+            client.set_tan_mechanism(mechanisms[int(choice)][0])
+
+    if client.is_tan_media_required() and not client.selected_tan_medium:
+        print("We need the name of the TAN medium, let's fetch them from the bank")
+        with client:
+            m = client.get_tan_media()
+        if len(m[1]) == 1:
+            client.set_tan_medium(m[1][0])
+        else:
+            print("Multiple tan media available. Which one do you prefer?")
+            for i, mm in enumerate(m[1]):
+                print(i,
+                      "Medium {p.tan_medium_name}: Phone no. {p.mobile_number_masked}, Last used {p.last_use}".format(
+                          p=mm))
+            choice = input("Choice: ").strip()
+            client.set_tan_medium(m[1][int(choice)])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 mt-940
-sepaxml==2.0.*
+sepaxml==2.1.*
 bleach

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'bleach',
         'mt-940',
         'requests',
-        'sepaxml~=2.0',
+        'sepaxml~=2.1',
     ],
 
     packages=find_packages(include=['fints', 'fints.*']),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from fints.segments.message import HNHBK3, HNVSK3, HNVSD1, HNHBS1
 from fints.formals import SecurityProfile, SecurityIdentificationDetails, SecurityDateTime, EncryptionAlgorithm, KeyName, BankIdentifier
 
 TEST_MESSAGES = {
-    os.path.basename(f).rsplit('.')[0]: open(f, 'rb').read() for f in 
+    os.path.basename(f).rsplit('.')[0]: open(f, 'rb').read() for f in
     glob.glob(os.path.join(os.path.dirname(__file__), "messages", "*.bin"))
 }
 
@@ -81,7 +81,7 @@ def fints_server():
                 result.append("HISYN::4:5+{}'".format(system_id).encode('us-ascii'))
 
             if b"'HKSPA:" in message:
-                result.append(b"HISPA::1:4+J:DE111234567800000001:GENODE00TES:00001::280:1234567890'")
+                result.append(b"HISPA::1:4+J:DE111234567800000001:GENODE23X42:00001::280:1234567890'")
 
             hkkaz = re.search(rb"'HKKAZ:(\d+):7\+[^+]+\+N(?:\+[^+]*\+[^+]*\+[^+]*\+([^+]*))?'", message)
             if hkkaz:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,7 +104,7 @@ def test_transfer_1step(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             Decimal('1.23'),
             'Test Sender',
@@ -128,7 +128,7 @@ def test_transfer_1step_regression(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             1.23,
             'Test Sender',
@@ -145,7 +145,7 @@ def test_transfer_2step(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             Decimal('2.34'),
             'Test Sender',
@@ -165,7 +165,7 @@ def test_transfer_2step_continue(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             Decimal('3.42'),
             'Test Sender',
@@ -187,7 +187,7 @@ def test_tan_wrong(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             Decimal('3.33'),
             'Test Sender',
@@ -204,7 +204,7 @@ def test_tan_hhduc(fints_client):
         a = fints_client.simple_sepa_transfer(
             accounts[0],
             'DE111234567800000002',
-            'GENODE00TES',
+            'GENODE23X42',
             'Test Receiver',
             Decimal('5.23'),
             'Test Sender',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,8 @@ def fints_client(fints_server):
         '12345678',
         'test1',
         '1234',
-        fints_server
+        fints_server,
+        product_id="TEST-123", product_version="1.2.3",
     )
 
 
@@ -34,6 +35,7 @@ def test_pin_wrong(fints_server):
         'test1',
         '99999',
         fints_server,
+        product_id="TEST-123", product_version="1.2.3",
     )
     with pytest.raises(FinTSClientPINError):
         with client:
@@ -55,6 +57,7 @@ def test_pin_locked(fints_server):
         'test1',
         '3938',
         fints_server,
+        product_id="TEST-123", product_version="1.2.3",
     )
     with pytest.raises(FinTSClientTemporaryAuthError):
         with client:
@@ -85,7 +88,8 @@ def test_resume(fints_client, fints_server):
         'test1',
         '1234',
         fints_server,
-        from_data=c_data
+        from_data=c_data,
+        product_id="TEST-123", product_version="1.2.3",
     )
     assert system_id == fints_client.system_id
 
@@ -104,7 +108,7 @@ def test_transfer_1step(fints_client):
             'Test Receiver',
             Decimal('1.23'),
             'Test Sender',
-            'Test transfer 1step'
+            'Test transfer 1step',
         )
 
         assert isinstance(a, TransactionResponse)

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -125,8 +125,8 @@ def test_invalid():
         m = FinTS3Parser().parse_message(message6)
 
 
-def test_robust_mode(mock):
-    mock.patch('fints.parser.robust_mode', True)
+def test_robust_mode(mocker):
+    mocker.patch('fints.parser.robust_mode', True)
 
     message1 = rb"""HNHBS:5:1'"""
     with pytest.warns(FinTSParserWarning, match='^Ignoring parser error.*: Required field'):


### PR DESCRIPTION
## The state of things

By now, all banks have implemented PSD2 in some capacity. However, the nuances are still very different and some are announcing further changes for December. Developing FinTS software requires lots of iterative testing, which is only efficiently possible for accounts one actually has access to. Therefore, it is unclear how long it will take until there is a **general** implementation that works "everywhere".

However, this branch contains a **working prototype** that can be used to at least **fetch transactions** from the banks listed below. You can install the version from this branch like this:

```
pip install -U "git+https://github.com/raphaelm/python-fints.git@psd2#egg=fints"
```

Please note that there are **API changes** compared to the currently released version and there **WILL** be **further API changes** before this gets merged and released.

## Usage / Call for Feedback

I'm more than happy for your feedback. However, to keep things in order, please **ONLY** comment to this pull request about your experiences with running the following script. Of course, you will need to change the details of your account or your bank, but please **do not make any other changes unless you need to** and **please describe all changes in your comment**. Please also clearly state which bank you are using.

If it does not work, it is very very helpful if you can email me the full debugging output to mail-fints@raphaelmichel.de. Of course, you can strip any personal data from the output, such as PINs, usernames, IBANs or transaction contents. Relevant is the structure of the FinTS data streams.

**Please post any questions that are not related to the following script in issue #72.**

```
import logging

import datetime

from fints.client import FinTS3PinTanClient, FinTSClientMode, FinTSUnsupportedOperation, NeedTANResponse
from fints.hhd.flicker import terminal_flicker_unix
import getpass

logging.basicConfig(level=logging.DEBUG)

f = FinTS3PinTanClient(
    '10010010', 'postbankid#profile', getpass.getpass('PIN: '), 'https://hbci.postbank.de/banking/hbci.do',
    mode=FinTSClientMode.INTERACTIVE,
)
f.fetch_tan_mechanisms()

try:
    with f:
        m = f.get_tan_media()
    f.set_tan_medium(m[1][0])
except FinTSUnsupportedOperation:
    print("TAN Mediums not supported.")

with f:
    if f.init_tan_response:
        print(f.init_tan_response.challenge)
        if getattr(f.init_tan_response, 'challenge_hhduc', None):
            try:
                terminal_flicker_unix(f.init_tan_response.challenge_hhduc)
            except KeyboardInterrupt:
                pass
        tan = input('Please enter TAN:')
        f.send_tan(f.init_tan_response, tan)

    # Fetch first account
    account = f.get_sepa_accounts()[0]

    res = f.get_transactions(account, datetime.date.today() - datetime.timedelta(days=30), datetime.date.today())
    while isinstance(res, NeedTANResponse):
        print(res.challenge)

        if getattr(res, 'challenge_hhduc', None):
            try:
                terminal_flicker_unix(res.challenge_hhduc)
            except KeyboardInterrupt:
                pass

        tan = input('Please enter TAN:')
        res = f.send_tan(res, tan)

    print("Transactions", res)

```

## API decisions to make

### Bootstrapping

[Bootstrapping authentication methods](https://github.com/raphaelm/python-fints/issues/72#issuecomment-529938043) requires multiple steps across three different dialogs. This is ugly, but I don't think we'll be able to hide it very much. This library is most commonly used in internal scripts (where it could just be hardcoded) or GUI-like applications (where it makes sense to ask the user for these details once or obtain them automatically once and then cache them), so I guess we'll just need to let the library user deal with the added complexity.

### Interactive mode

To put things in very simple terms, PSD2 requires us to expect a two-factor authentification (2FA) to be required at *any* point without warning, e.g. during dialog initialization or when doing commands based on unknown parameters (e.g. every time you fetch data older than 90 days). 2FA requires user interaction which is not possible if the software is running in the background.

However, especially with approaches like pushTAN or mobileTAN/smsTAN, this is an issue because if the software runs in the background, it will spam the account holder with TAN messages. In case of mobileTAN, this might even cost a fee every time it happens. Therefore, @henryk proposed a "non-interactive mode" in https://github.com/raphaelm/python-fints/issues/72#issuecomment-530057625

This branch currently implements such a mode selection and requires users to select "interactive mode". With the banks I have access to (e.g. GLS Bank), it currently seems *impossible* to implement such a non-interactive mode, as the bank will just refuse dialog initialization without HKTAN6, no matter if a TAN is required.

Unless someone comes up with a different idea on how to realize a non-interactive mode, I think we can remove the mode selection alltogether again.

## To do list

- [x] Decide on an API surface
- [x] Clean up implementation
- [x] Test with more banks
- [x] Adjust get_holdings and get_transactions_xml to two-step variants and new signature of touchdown helpers
- [x] Write documentation

## Tests currently passing

| Bank          | Dialog initialization | Get transactions <90 days | Get transactions >90 days | Transfers/Debits |
| --- | --- | --- | --- | --- |
| GLS Bank | Yes | Yes | Yes | ? |
| BBBank | Yes | Yes | Yes | ? |
| Triodos | Yes | Yes | ? | ? |
| Postbank | Yes? | Yes | Yes | ? |