### PR TITLE
Add configuration and code to opt-in to reduced logging.

### DIFF
--- a/fints/connection.py
+++ b/fints/connection.py
@@ -3,12 +3,25 @@ import io
 import logging
 
 import requests
-from fints.utils import Password
+from fints.utils import Password, log_configuration
 
 from .exceptions import *
 from .message import FinTSInstituteMessage, FinTSMessage
+from .types import SegmentSequence
 
 logger = logging.getLogger(__name__)
+
+
+def reduce_message_for_log(msg):
+    log_msg = msg
+    if log_configuration.reduced:
+        # Try to find a single inner message
+        if len(log_msg.segments) == 4 and log_msg.segments[2].header.type == 'HNVSD':
+            log_msg = log_msg.segments[2]
+            if len(log_msg.data.segments) > 2 and log_msg.data.segments[0].header.type == "HNSHK" and \
+                    log_msg.data.segments[-1].header.type == "HNSHA":
+                log_msg = SegmentSequence(segments=log_msg.data.segments[1:-1])
+    return log_msg
 
 
 class FinTSHTTPSConnection:
@@ -18,8 +31,9 @@ class FinTSHTTPSConnection:
     def send(self, msg: FinTSMessage):
         log_out = io.StringIO()
         with Password.protect():
-            msg.print_nested(stream=log_out, prefix="\t")
-            logger.debug("Sending >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n{}\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n".format(log_out.getvalue()))
+            log_msg = reduce_message_for_log(msg)
+            log_msg.print_nested(stream=log_out, prefix="\t")
+            logger.debug("Sending {}>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n{}\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n".format("(abbrv.)" if log_configuration.reduced else "", log_out.getvalue()))
             log_out.truncate(0)
 
         r = requests.post(
@@ -36,6 +50,7 @@ class FinTSHTTPSConnection:
         retval = FinTSInstituteMessage(segments=response)
 
         with Password.protect():
-            retval.print_nested(stream=log_out, prefix="\t")
-            logger.debug("Received <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n{}\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n".format(log_out.getvalue()))
+            log_msg = reduce_message_for_log(retval)
+            log_msg.print_nested(stream=log_out, prefix="\t")
+            logger.debug("Received {}<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n{}\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n".format("(abbrv.)" if log_configuration.reduced else "", log_out.getvalue()))
         return retval

--- a/fints/utils.py
+++ b/fints/utils.py
@@ -2,6 +2,7 @@ import base64
 import inspect
 import json
 import re
+import threading
 import zlib
 from contextlib import contextmanager
 from datetime import datetime
@@ -329,3 +330,30 @@ def minimal_interactive_cli_bootstrap(client):
                           p=mm))
             choice = input("Choice: ").strip()
             client.set_tan_medium(m[1][int(choice)])
+
+
+class LogConfiguration(threading.local):
+    """Thread-local configuration object to guide log output.
+
+    reduced: Reduce verbosity of logging output by suppressing the encrypting/signature elements and outputting the payload only.
+    """
+    def __init__(self, reduced=False):
+        super().__init__()
+        self.reduced = reduced
+
+    @staticmethod
+    def set(reduced=False):
+        """Permanently change the log configuration for this thread."""
+        log_configuration.reduced = reduced
+
+    @staticmethod
+    @contextmanager
+    def changed(reduced=False):
+        """Temporarily change the log configuration for this thread."""
+        old_reduced = log_configuration.reduced
+        log_configuration.set(reduced=reduced)
+        yield
+        log_configuration.set(reduced=old_reduced)
+
+
+log_configuration = LogConfiguration()


### PR DESCRIPTION
Currently this strips all the boilerplate prefix and suffix from the packet dump in FinTSHTTPSConnection.send(), only showing the net payload.