### PR TITLE
Import from collections.abc, not collections

### DIFF
--- a/fints/parser.py
+++ b/fints/parser.py
@@ -1,6 +1,6 @@
 import re
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 from enum import Enum
 
 from .formals import (

--- a/fints/types.py
+++ b/fints/types.py
@@ -1,4 +1,5 @@
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from contextlib import suppress
 
 from .exceptions import FinTSNoResponseError


### PR DESCRIPTION
This is possible since py3.3 and has been deprecated for a while.
In py3.10 (set to release in september), the old option will not work
anymore.