### PR TITLE
Add SEPA-instant payment functionality

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -37,7 +37,7 @@ from .segments.dialog import HIRMG2, HIRMS2, HISYN4, HKSYN3
 from .segments.journal import HKPRO3, HKPRO4
 from .segments.saldo import HKSAL5, HKSAL6, HKSAL7
 from .segments.statement import DKKKU2, HKKAZ5, HKKAZ6, HKKAZ7, HKCAZ1
-from .segments.transfer import HKCCM1, HKCCS1, HKIPZ2, HKIPM2
+from .segments.transfer import HKCCM1, HKCCS1, HKIPZ1, HKIPM1
 from .types import SegmentSequence
 from .utils import (
     MT535_Miniparser, Password, SubclassesMixin,
@@ -801,9 +801,9 @@ class FinTS3Client:
 
         with self._get_dialog() as dialog:
             if multiple:
-                command_class = HKIPM2 if instant_payment else HKCCM1
+                command_class = HKIPM1 if instant_payment else HKCCM1
             else:
-                command_class = HKIPZ2 if instant_payment else HKCCS1
+                command_class = HKIPZ1 if instant_payment else HKCCS1
 
             hiccxs, hkccx = self._find_highest_supported_command(
                 command_class,
@@ -816,8 +816,8 @@ class FinTS3Client:
                 sepa_pain_message=pain_message.encode(),
             )
 
-            if instant_payment:
-                seg.allow_convert_sepa_transfer = True
+            # if instant_payment:
+            #     seg.allow_convert_sepa_transfer = True
 
             if multiple:
                 if hiccxs.parameter.sum_amount_required and control_sum is None:

--- a/fints/client.py
+++ b/fints/client.py
@@ -37,7 +37,7 @@ from .segments.dialog import HIRMG2, HIRMS2, HISYN4, HKSYN3
 from .segments.journal import HKPRO3, HKPRO4
 from .segments.saldo import HKSAL5, HKSAL6, HKSAL7
 from .segments.statement import DKKKU2, HKKAZ5, HKKAZ6, HKKAZ7, HKCAZ1
-from .segments.transfer import HKCCM1, HKCCS1, HKIPZ1, HKIPM1
+from .segments.transfer import HKCCM1, HKCCS1, HKIPZ2, HKIPM2
 from .types import SegmentSequence
 from .utils import (
     MT535_Miniparser, Password, SubclassesMixin,
@@ -801,9 +801,9 @@ class FinTS3Client:
 
         with self._get_dialog() as dialog:
             if multiple:
-                command_class = HKIPM1 if instant_payment else HKCCM1
+                command_class = HKIPM2 if instant_payment else HKCCM1
             else:
-                command_class = HKIPZ1 if instant_payment else HKCCS1
+                command_class = HKIPZ2 if instant_payment else HKCCS1
 
             hiccxs, hkccx = self._find_highest_supported_command(
                 command_class,
@@ -815,6 +815,9 @@ class FinTS3Client:
                 sepa_descriptor=pain_descriptor,
                 sepa_pain_message=pain_message.encode(),
             )
+
+            if instant_payment:
+                seg.allow_convert_sepa_transfer = True
 
             if multiple:
                 if hiccxs.parameter.sum_amount_required and control_sum is None:

--- a/fints/segments/transfer.py
+++ b/fints/segments/transfer.py
@@ -12,13 +12,22 @@ class HKCCS1(FinTS3Segment):
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
 
-class HKIPZ1(FinTS3Segment):
-    """SEPA-instant Einzelüberweisung, version 1
+# class HKIPZ1(FinTS3Segment):
+#     """SEPA-instant Einzelüberweisung, version 1
+#     
+#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+
+class HKIPZ2(FinTS3Segment):
+    """SEPA-instant Einzelüberweisung, version 2
     
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+    allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
 
 
 class HKCCM1(FinTS3Segment):
@@ -32,8 +41,18 @@ class HKCCM1(FinTS3Segment):
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
 
     
-class HKIPM1(FinTS3Segment):
-    """SEPA-instant Sammelüberweisung, version 1
+# class HKIPM1(FinTS3Segment):
+#     """SEPA-instant Sammelüberweisung, version 1
+#     
+#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+#     sum_amount = DataElementGroupField(type=Amount1, _d="Summenfeld")
+#     request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
+#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+
+class HKIPM2(FinTS3Segment):
+    """SEPA-instant Sammelüberweisung, version 2
     
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
@@ -41,6 +60,7 @@ class HKIPM1(FinTS3Segment):
     request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+    allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
 
 
 class HICCMS1(ParameterSegment):

--- a/fints/segments/transfer.py
+++ b/fints/segments/transfer.py
@@ -12,10 +12,29 @@ class HKCCS1(FinTS3Segment):
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
 
+class HKIPZ1(FinTS3Segment):
+    """SEPA-instant Einzelüberweisung, version 1
+    
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+    account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+    sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+    sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+
 
 class HKCCM1(FinTS3Segment):
     """SEPA-Sammelüberweisung, version 1
 
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+    account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+    sum_amount = DataElementGroupField(type=Amount1, _d="Summenfeld")
+    request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
+    sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+    sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+
+    
+class HKIPM1(FinTS3Segment):
+    """SEPA-instant Sammelüberweisung, version 1
+    
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
     sum_amount = DataElementGroupField(type=Amount1, _d="Summenfeld")

--- a/fints/segments/transfer.py
+++ b/fints/segments/transfer.py
@@ -12,22 +12,22 @@ class HKCCS1(FinTS3Segment):
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
 
-# class HKIPZ1(FinTS3Segment):
-#     """SEPA-instant Einzelüberweisung, version 1
-#     
-#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
-#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
-#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
-#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
-
-class HKIPZ2(FinTS3Segment):
-    """SEPA-instant Einzelüberweisung, version 2
+class HKIPZ1(FinTS3Segment):
+    """SEPA-instant Einzelüberweisung, version 1
     
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
-    allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
+
+# class HKIPZ2(FinTS3Segment):
+#     """SEPA-instant Einzelüberweisung, version 2
+#     
+#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+#     allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
 
 
 class HKCCM1(FinTS3Segment):
@@ -41,18 +41,8 @@ class HKCCM1(FinTS3Segment):
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
 
     
-# class HKIPM1(FinTS3Segment):
-#     """SEPA-instant Sammelüberweisung, version 1
-#     
-#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
-#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
-#     sum_amount = DataElementGroupField(type=Amount1, _d="Summenfeld")
-#     request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
-#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
-#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
-
-class HKIPM2(FinTS3Segment):
-    """SEPA-instant Sammelüberweisung, version 2
+class HKIPM1(FinTS3Segment):
+    """SEPA-instant Sammelüberweisung, version 1
     
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
@@ -60,7 +50,17 @@ class HKIPM2(FinTS3Segment):
     request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
-    allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
+
+# class HKIPM2(FinTS3Segment):
+#     """SEPA-instant Sammelüberweisung, version 2
+#     
+#     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+#     account = DataElementGroupField(type=KTI1, _d="Kontoverbindung international")
+#     sum_amount = DataElementGroupField(type=Amount1, _d="Summenfeld")
+#     request_single_booking = DataElementField(type='jn', _d="Einzelbuchung gewünscht")
+#     sepa_descriptor = DataElementField(type='an', max_length=256, _d="SEPA Descriptor")
+#     sepa_pain_message = DataElementField(type='bin', _d="SEPA pain message")
+#     allow_convert_sepa_transfer = DataElementField(type="jn", _d="Allow conversion to SEPA transfer if instant-payment not supported")
 
 
 class HICCMS1(ParameterSegment):


### PR DESCRIPTION
I added a simple and crude way of using the SEPA Instant payment (Sofort Überweisung) functionality with a simple kw argument.

By no means a perfect implementation but it is a nice refinement to the present simple_sepa_transfer functionality in my opinion.