### PR TITLE
Add optional TAN medium field to constructor of FinTS3PinTanClient (fix #121, #106)

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -1101,13 +1101,13 @@ IMPLEMENTED_HKTAN_VERSIONS = {
 
 class FinTS3PinTanClient(FinTS3Client):
 
-    def __init__(self, bank_identifier, user_id, pin, server, customer_id=None, *args, **kwargs):
+    def __init__(self, bank_identifier, user_id, pin, server, customer_id=None, tan_medium=None, *args, **kwargs):
         self.pin = Password(pin) if pin is not None else pin
         self._pending_tan = None
         self.connection = FinTSHTTPSConnection(server)
         self.allowed_security_functions = []
         self.selected_security_function = None
-        self.selected_tan_medium = None
+        self.selected_tan_medium = tan_medium
         self._bootstrap_mode = True
         super().__init__(bank_identifier=bank_identifier, user_id=user_id, customer_id=customer_id, *args, **kwargs)
 


### PR DESCRIPTION
As detailed in my comment on #121, this pull request is a tiny hotfix which allows users to manually set a TAN medium when initializing a new FinTS3PinTanClient. Ideally, we would build a better solution that automatically requests TAN media and sets it directly if there is only one available (I suspect this is the case for the vast majority of users). Nonetheless, this is a very quick and dirty fix to at least allow library users to control the TAN medium manually and avoid errors on initialization. 

This fixes issues #121 and #106.