### PR TITLE
Remove Python 3.6 from the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
This version of Python is no longer supported on GitHub Actions, apparently.

See the corresponding failing build:
https://github.com/raphaelm/python-fints/actions/runs/4773952638/jobs/8487328497