### PR TITLE
Add HISPAS3 for Baader Bank support

### DIFF
--- a/fints/formals.py
+++ b/fints/formals.py
@@ -954,6 +954,16 @@ class GetSEPAAccountParameter1(DataElementGroup):
     structured_purpose_allowed = DataElementField(type='jn', _d="Strukturierter Verwendungszweck erlaubt")
     supported_sepa_formats = DataElementField(type='an', max_length=256, max_count=99, required=False, _d="Unterstützte SEPA-Datenformate")
 
+class GetSEPAAccountParameter3(DataElementGroup):
+    """Parameter SEPA-Kontoverbindung anfordern, version 3
+
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle """
+    single_account_query_allowed = DataElementField(type='jn', _d="Einzelkontenabruf erlaubt")
+    national_account_allowed = DataElementField(type='jn', _d="Nationale Kontoverbindung erlaubt")
+    structured_purpose_allowed = DataElementField(type='jn', _d="Strukturierter Verwendungszweck erlaubt")
+    max_number_responses_allowed = DataElementField(type='jn', _d="Eingabe Anzahl Einträge erlaubt")
+    cutoff_days = DataElementField(type='num', max_length=2, _d="Anzahl reservierter Verwendungszweckstellen")
+    supported_sepa_formats = DataElementField(type='an', max_length=256, max_count=99, required=False, _d="Unterstützte SEPA-Datenformate")
 
 class SupportedMessageTypes(DataElementGroup):
     """Unterstützte camt-Messages

--- a/fints/segments/accounts.py
+++ b/fints/segments/accounts.py
@@ -1,5 +1,5 @@
 from ..fields import DataElementGroupField
-from ..formals import KTZ1, Account3, GetSEPAAccountParameter1
+from ..formals import KTZ1, Account3, GetSEPAAccountParameter1, GetSEPAAccountParameter3
 from .base import FinTS3Segment, ParameterSegment
 
 
@@ -24,3 +24,9 @@ class HISPAS1(ParameterSegment):
 
     Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle"""
     parameter = DataElementGroupField(type=GetSEPAAccountParameter1, _d="Parameter SEPA-Kontoverbindung anfordern")
+
+class HISPAS3(ParameterSegment):
+    """SEPA-Kontoverbindung anfordern, Parameter, version 3
+
+    Source: FinTS Financial Transaction Services, Schnittstellenspezifikation, Messages -- Multibankfähige Geschäftsvorfälle"""
+    parameter = DataElementGroupField(type=GetSEPAAccountParameter3, _d="Parameter SEPA-Kontoverbindung anfordern")


### PR DESCRIPTION
HISPAS3 is needed in order to be able to call `get_information()` on a Baader Bank account. So I added it from the spec.