### PR TITLE
Use a requests session per FinTSHTTPSConnection

### DIFF
--- a/fints/connection.py
+++ b/fints/connection.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 class FinTSHTTPSConnection:
     def __init__(self, url):
         self.url = url
+        self.session = requests.session()
 
     def send(self, msg: FinTSMessage):
         log_out = io.StringIO()
@@ -22,7 +23,7 @@ class FinTSHTTPSConnection:
             logger.debug("Sending >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n{}\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n".format(log_out.getvalue()))
             log_out.truncate(0)
 
-        r = requests.post(
+        r = self.session.post(
             self.url, data=base64.b64encode(msg.render_bytes()),
             headers={
                 'Content-Type': 'text/plain',


### PR DESCRIPTION
This creates a requests session per FinTSHTTPSConnection. This mostly results in requests reusing the HTTPS connection, leading to fewer roundtrips and lower latency overall. It would also allow cookie sharing, etc., but I don't think that matters at all for any FinTS stuff. Given that it's also an isolated session per FinTSHTTPSConnection, I don't see how this could have a negative impact.

Tested with my bank.