### PR TITLE
Ensure that NeedTANResponse is marked as decoupled even in case of multiple response codes (0030 and 3955)

### DIFF
--- a/fints/dialog.py
+++ b/fints/dialog.py
@@ -92,8 +92,12 @@ class FinTSDialog:
                                 retval.find_segment_first('HITAN'),
                                 '_continue_dialog_initialization',
                                 self.client.is_challenge_structured(),
-                                resp.code == '3955',
+                                False,
                             )
+                            if resp.code == '3955':
+                                self.client.init_tan_response.decoupled = True
+                                break
+
                 self.need_init = False
                 return retval
             except Exception as e:


### PR DESCRIPTION
As described in https://github.com/raphaelm/python-fints/issues/179#issuecomment-2568421741 `NeedTANResponse` may not be marked as `decoupled` in case of multiple response codes, i.e. 0030 and 3955.