### PR TITLE
Fix HNSHK security profile version for two-step PIN/TAN

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -1305,6 +1305,9 @@ class FinTS3PinTanClient(FinTS3Client):
         else:
             self.set_tan_mechanism('999')
             self._ensure_system_id()
+        # Bootstrap phase (anonymous dialog with sf=999) is complete.
+        # Reset so that errors in subsequent authenticated dialogs are properly raised.
+        self._bootstrap_mode = False
         if self.get_current_tan_mechanism():
             # We already got a reply through _ensure_system_id
             return self.get_current_tan_mechanism()

--- a/fints/security.py
+++ b/fints/security.py
@@ -99,13 +99,14 @@ class PinTanAuthenticationMechanism(AuthenticationMechanism):
         self.pin = pin
         self.pending_signature = None
         self.security_function = None
+        self.security_method_version = 1
 
     def sign_prepare(self, message: FinTSMessage):
         _now = datetime.datetime.now()
         rand = random.SystemRandom()
 
         self.pending_signature = HNSHK4(
-            security_profile=SecurityProfile(SecurityMethod.PIN, 1),
+            security_profile=SecurityProfile(SecurityMethod.PIN, self.security_method_version),
             security_function=self.security_function,
             security_reference=rand.randint(1000000, 9999999),
             security_application_area=SecurityApplicationArea.SHM,
@@ -178,6 +179,7 @@ class PinTanTwoStepAuthenticationMechanism(PinTanAuthenticationMechanism):
         super().__init__(*args, **kwargs)
         self.client = client
         self.security_function = security_function
+        self.security_method_version = 2
 
     def _get_tan(self):
         retval = self.client._pending_tan


### PR DESCRIPTION
## Summary

- **HNSHK signature header** always used `SecurityProfile(PIN, 1)` (one-step) even when two-step TAN authentication (e.g. `sf=904`) was active. The HNVSK encryption header correctly used `PIN:2`, but HNSHK still said `PIN:1`.
- Banks that strictly validate the security profile version — notably **HypoVereinsbank (UniCredit)** — rejected the HKTAN segment with error `9210` ("Auftrag abgelehnt. Kein eingereichter Auftrag gefunden") because the signature claimed one-step while a two-step HKTAN segment was present.
- Additionally, `_bootstrap_mode` was never reset after `fetch_tan_mechanisms()`, causing `9075` SCA errors to be silently swallowed instead of properly raised.

## Changes

1. **`fints/security.py`**: `PinTanAuthenticationMechanism` now uses a `security_method_version` attribute (default `1`) for the HNSHK security profile. `PinTanTwoStepAuthenticationMechanism` overrides it to `2`, matching the HNVSK behavior.
2. **`fints/client.py`**: `_bootstrap_mode` is reset to `False` after `fetch_tan_mechanisms()` completes, so that subsequent dialog errors (especially `9075`) are properly raised.

## Test plan

- [x] Tested with HypoVereinsbank (BLZ 70020270, appTAN sf=904): Dialog init now receives `HITAN` with challenge instead of `9210`
- [x] Verified DKB, VR Bank, and Sparkasse still work (these banks don't strictly check the profile version)
- [x] Successfully retrieved 124 transactions + 3 SEPA accounts from HVB after fix

Fixes #213