### PR TITLE
Wrap transport errors as FinTSConnectionError

### DIFF
--- a/fints/connection.py
+++ b/fints/connection.py
@@ -37,12 +37,15 @@ class FinTSHTTPSConnection:
             logger.debug("Sending {}>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n{}\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n".format("(abbrv.)" if log_configuration.reduced else "", log_out.getvalue()))
             log_out.truncate(0)
 
-        r = self.session.post(
-            self.url, data=base64.b64encode(msg.render_bytes()),
-            headers={
-                'Content-Type': 'text/plain',
-            },
-        )
+        try:
+            r = self.session.post(
+                self.url, data=base64.b64encode(msg.render_bytes()),
+                headers={
+                    'Content-Type': 'text/plain',
+                },
+            )
+        except (requests.RequestException, OSError) as e:
+            raise FinTSConnectionError("Could not connect to FinTS endpoint: {}".format(e)) from e
 
         if r.status_code < 200 or r.status_code > 299:
             raise FinTSConnectionError('Bad status code {}'.format(r.status_code))

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,30 @@
+import pytest
+import requests
+
+from fints.connection import FinTSHTTPSConnection
+from fints.exceptions import FinTSConnectionError
+
+
+class DummyMessage:
+    segments = []
+
+    def print_nested(self, stream=None, **kwargs):
+        pass
+
+    def render_bytes(self):
+        return b"dummy"
+
+
+def test_send_wraps_transport_errors():
+    connection = FinTSHTTPSConnection("https://example.invalid/fints")
+
+    def raise_timeout(*args, **kwargs):
+        raise requests.exceptions.Timeout("request timed out")
+
+    connection.session.post = raise_timeout
+
+    with pytest.raises(FinTSConnectionError) as excinfo:
+        connection.send(DummyMessage())
+
+    assert "request timed out" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, requests.exceptions.Timeout)


### PR DESCRIPTION
Network-level failures during dialog initialization currently bubble up as arbitrary exceptions from requests/socket code. FinTSDialog.init catches those broad exceptions and re-raises FinTSDialogInitError with an authentication-focused message, which makes DNS/TLS/TCP failures look like wrong credentials.\n\nThis wraps requests and socket-level failures from FinTSHTTPSConnection.send as FinTSConnectionError. FinTSDialog.init already preserves FinTSConnectionError, so callers can distinguish endpoint/transport failures from authentication failures.\n\nTested with:\n\n    uv run --with pytest pytest tests/test_connection.py