### PR TITLE
Loosen lxml pin to allow 6.1.x (security: CVE-2026-41066)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "requests",
   "sepaxml~=2.7",
   "enum-tools~=0.12.0",
-  "lxml~=6.0.2",
+  "lxml>=6.0.2,<7",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## What

Loosen the lxml cap from `lxml~=6.0.2` to `lxml>=6.0.2,<7`.

## Why

lxml **6.1.0** fixes **CVE-2026-41066** (GHSA-vfmq-68hx-4jfw / PYSEC-2026-87) — an
XXE local-file read via the `resolve_entities=True` parser default. The current
`lxml~=6.0.2` cap (`<6.1`) prevents any project depending on python-fints from
upgrading lxml to the patched 6.1.x, so the security fix is blocked downstream.

## Compatibility

python-fints uses lxml only through `etree.fromstring` (`fints/camt_parser.py`).
Smoke-tested against lxml 6.1.0:

- `import fints, fints.client, fints.camt_parser` → ok
- `etree.fromstring(b'<Doc xmlns="urn:test">…</Doc>')` (namespaced parse) → ok

No lxml API used by python-fints changed between 6.0 and 6.1; 6.1.0 only changes
the parser's default entity-resolution mode, which python-fints doesn't rely on.

## Change

One line in `pyproject.toml`: `lxml~=6.0.2` → `lxml>=6.0.2,<7`.
