### PR TITLE
Fix VoP handling for banks that do not report the result inline

### DIFF
--- a/fints/client.py
+++ b/fints/client.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import time
 from abc import ABCMeta, abstractmethod
 from base64 import b64decode
 from collections import OrderedDict
@@ -1438,6 +1439,85 @@ class FinTS3PinTanClient(FinTS3Client):
 
             return resume_func(command_seg, response)
         
+    def _find_vop_aufsetzpunkt(self, response):
+        """Extract the touchdown point (Aufsetzpunkt) from a HIRMS 3040 response.
+
+        Banks return it as the first parameter of response code 3040
+        ("Es liegen weitere Informationen vor").
+        """
+        for hirms_seg in response.find_segments(HIRMS2):
+            for resp in hirms_seg.responses:
+                if resp.code == '3040' and resp.parameters:
+                    return resp.parameters[0]
+        return None
+
+    def _poll_vop_result(self, dialog, response, hivpp, vop_standard, timeout_seconds=60):
+        """Poll for an asynchronously produced VoP result (FinTS spec E.8.3.1).
+
+        Some banks (Atruvia: Volksbank, GLS, VR) do not return the VoP result
+        inline. Their HIVPP carries neither ``vop_id`` nor ``vop_single_result``,
+        only a ``polling_id`` and ``wait_for_seconds``, accompanied by response
+        codes 3905 ("no challenge created") and 3040 with the touchdown point.
+
+        This re-sends HKVPP with ``polling_id`` **and** ``aufsetzpunkt`` until the
+        bank returns a result. Both are mandatory -- sending only one yields 9210.
+
+        The loop terminates on the presence of ``vop_id`` or
+        ``payment_status_report`` rather than on a specific response code:
+        depending on the server release, Atruvia completes the check with either
+        3090 or 0020/0025, so checking for a code would loop forever on the other
+        variant.
+
+        The wait interval is taken from each response anew (``wait_for_seconds``)
+        instead of using a fixed delay.
+
+        Raises:
+            FinTSClientError: if no result is available within ``timeout_seconds``.
+                Deliberately an exception rather than falling through: without a
+                result there is nothing to approve and the order was not executed,
+                so a caller receiving a warnings-only response could mistake it
+                for success.
+        """
+        from .segments.auth import HKVPP1
+
+        aufsetzpunkt = self._find_vop_aufsetzpunkt(response)
+        deadline = time.monotonic() + timeout_seconds
+        attempt = 0
+
+        while True:
+            attempt += 1
+            wait_seconds = int(hivpp.wait_for_seconds) if hivpp.wait_for_seconds else 2
+
+            if time.monotonic() + wait_seconds > deadline:
+                raise FinTSClientError(
+                    "VoP result not available after {} attempt(s) within {}s "
+                    "(polling_id={!r}). The transfer was NOT executed.".format(
+                        attempt - 1, timeout_seconds, hivpp.polling_id))
+
+            logger.info("VoP polling attempt %d (polling_id=%r, aufsetzpunkt=%r, wait=%ds)",
+                        attempt, hivpp.polling_id, aufsetzpunkt, wait_seconds)
+            time.sleep(wait_seconds)
+
+            # HKVPP only -- no payment order, no HKTAN. The original order is held
+            # by the bank awaiting approval; re-sending it starts a NEW VoP check.
+            poll_response = dialog.send(HKVPP1(
+                supported_reports=PSRD1(psrd=[vop_standard]),
+                polling_id=hivpp.polling_id,
+                aufsetzpunkt=aufsetzpunkt,
+            ))
+            hivpp = poll_response.find_segment_first(HIVPP1, throw=True)
+
+            if hivpp.vop_id or hivpp.payment_status_report:
+                logger.info("VoP result available after %d attempt(s) (vop_id=%r)",
+                            attempt, hivpp.vop_id)
+                return hivpp
+
+            # Not ready yet: the bank may supply a new touchdown point. The
+            # previous one stays valid as long as it does not.
+            next_aufsetzpunkt = self._find_vop_aufsetzpunkt(poll_response)
+            if next_aufsetzpunkt:
+                aufsetzpunkt = next_aufsetzpunkt
+
     def _send_pay_with_possible_retry(self, dialog, command_seg, resume_func):
         """
         This adds VoP under the assumption that TAN will be sent,
@@ -1470,9 +1550,41 @@ class FinTS3PinTanClient(FinTS3Client):
                 if vop_standard:
                     hivpp = response.find_segment_first(HIVPP1, throw=True)
 
+                    # Asynchronous VoP flow: the bank has not checked the payee yet
+                    # and hands us a polling_id instead of a result. Without polling
+                    # this inevitably ends in 3945 ("approval without VoP confirmation
+                    # not possible") and the transfer can never be executed.
+                    #
+                    # `polled` records which flow we are in. This is what keeps the
+                    # change backwards compatible: banks answering inline (e.g.
+                    # Sparkassen, which already fire the pushTAN in step 1) fall
+                    # through to the unchanged branch below and keep their TAN
+                    # detection. Branching on the presence of `vop_id` alone would
+                    # take that path away from them.
+                    polled = False
+                    if not hivpp.vop_id and hivpp.polling_id:
+                        hivpp = self._poll_vop_result(dialog, response, hivpp, vop_standard)
+                        polled = True
+
                     vop_result = hivpp.vop_single_result
+                    # On polled responses vop_single_result is empty (result=None);
+                    # the outcome lives in payment_status_report (pain.002). Read
+                    # defensively instead of dereferencing.
+                    result_code = getattr(vop_result, 'result', None) if vop_result is not None else None
+
+                    # Asynchronous flow: the bank produced its result and now awaits
+                    # confirmation via HKVPA. Hand the caller the HIVPP carrying
+                    # vop_id and the pain.002 so it can decide whether to approve --
+                    # which is the entire point of VoP.
+                    if polled:
+                        return NeedVOPResponse(
+                            vop_result=hivpp,
+                            command_seg=command_seg,
+                            resume_method=resume_func,
+                        )
+
                      # Not Applicable, No Match, Close Match, or exact match but still requires confirmation
-                    if vop_result.result in ('RVNA', 'RVNM', 'RVMC')  or (vop_result.result == 'RCVC' and '3945' in [res.code for res in response.responses(tan_seg)]): 
+                    if result_code in ('RVNA', 'RVNM', 'RVMC')  or (result_code == 'RCVC' and '3945' in [res.code for res in response.responses(tan_seg)]):
                         return NeedVOPResponse(
                             vop_result=hivpp,
                             command_seg=command_seg,

--- a/fints/client.py
+++ b/fints/client.py
@@ -1595,6 +1595,24 @@ class FinTS3PinTanClient(FinTS3Client):
                         for r in seg.responses
                     ]
 
+                    # Some banks (Commerzbank) omit vop_single_result entirely and report
+                    # the outcome only inside payment_status_report (a pain.002 document
+                    # carrying e.g. <GrpSts>RCVC</GrpSts>). result_code is None there, so
+                    # neither branch below can match -- no NeedVOPResponse is produced, no
+                    # HKVPA is ever sent, and the order is rejected with 3945 after the TAN.
+                    #
+                    # A present vop_id together with a status report means the bank has
+                    # completed its check and is waiting for the approval, so hand the
+                    # caller a NeedVOPResponse. Banks that fill vop_single_result (e.g.
+                    # Sparkassen, where a separate HKVPA is answered with 9010) are not
+                    # affected: result_code is set for them and this branch is skipped.
+                    if result_code is None and hivpp.vop_id and hivpp.payment_status_report:
+                        return NeedVOPResponse(
+                            vop_result=hivpp,
+                            command_seg=command_seg,
+                            resume_method=resume_func,
+                        )
+
                      # Not Applicable, No Match, Close Match, or exact match but still requires confirmation
                     if result_code in ('RVNA', 'RVNM', 'RVMC')  or (result_code == 'RCVC' and '3945' in all_codes):
                         return NeedVOPResponse(

--- a/fints/client.py
+++ b/fints/client.py
@@ -1583,8 +1583,20 @@ class FinTS3PinTanClient(FinTS3Client):
                             resume_method=resume_func,
                         )
 
+                    # Look for 3945 ("approval without VoP confirmation not possible")
+                    # in ALL response segments, not only those attached to the TAN
+                    # segment. Commerzbank attaches it elsewhere: the condition below
+                    # then never matched, no NeedVOPResponse was produced, the flow fell
+                    # through to TAN handling, and HKVPA was never sent -- leaving the
+                    # transfer permanently rejected with 3945.
+                    all_codes = [
+                        r.code
+                        for seg in response.find_segments((HIRMG2, HIRMS2))
+                        for r in seg.responses
+                    ]
+
                      # Not Applicable, No Match, Close Match, or exact match but still requires confirmation
-                    if result_code in ('RVNA', 'RVNM', 'RVMC')  or (result_code == 'RCVC' and '3945' in [res.code for res in response.responses(tan_seg)]):
+                    if result_code in ('RVNA', 'RVNM', 'RVMC')  or (result_code == 'RCVC' and '3945' in all_codes):
                         return NeedVOPResponse(
                             vop_result=hivpp,
                             command_seg=command_seg,


### PR DESCRIPTION
Fixes the VoP handling reported in #220.

## Summary

Banks report Verification of Payee results in three different shapes. python-fints
currently recognises only one of them, so on the other two **every transfer to a
third-party payee fails** — with `3945 Freigabe ohne VOP-Bestätigung nicht möglich`
— and can never be executed.

| Bank | Where the VoP result appears | Before | After |
|---|---|---|---|
| Sparkasse | inline in `vop_single_result` | works | unchanged |
| Atruvia (Volksbank, GLS, VR) | asynchronous, behind a `polling_id` | always `3945` | executes |
| Commerzbank | only inside `payment_status_report` | always `3945` | executes |

All three verified against real bank dialogs.

## The three cases

**1. Asynchronous result (Atruvia)** — `HIVPP` carries neither `vop_id` nor
`vop_single_result`, only a `polling_id` and `wait_for_seconds`, accompanied by `3905`
("no challenge created") and `3040` with a touchdown point. The client has to ask
again. It never did.

**2. `3945` attached elsewhere (Commerzbank)** — the existing check looked for the
code only in responses tied to the TAN segment:

```python
'3945' in [res.code for res in response.responses(tan_seg)]
```

Some banks attach it to a different segment, so the condition never matched.

**3. Result only in the status report (Commerzbank)** — this bank omits
`vop_single_result` entirely and reports the outcome solely inside
`payment_status_report`, a pain.002 document:

```
HIVPP1(
    vop_id                = b'...',
    vop_id_valid_until    = ...,
    payment_status_report = <pain.002 with GrpSts RCVC>,
    manual_authorization_notice = '...'
)
HITAN6(challenge = 'Dies ist Ihre photoTAN Challenge.')
```

With `vop_single_result` absent, `result_code` is `None` and **neither** existing
branch can match — regardless of how widely `3945` is searched. No `NeedVOPResponse`
is produced, `HKVPA` is never sent, and the order is rejected after the TAN.

## Changes

* `_find_vop_aufsetzpunkt()` — reads the touchdown point from HIRMS code `3040`.
* `_poll_vop_result()` — re-sends `HKVPP` with `polling_id` **and** `aufsetzpunkt`
  until a result arrives. Both are mandatory; sending only one yields `9210`
  (independently confirmed by two reporters in #220).
* `3945` is now looked for across all HIRMG/HIRMS segments.
* A present `vop_id` together with a `payment_status_report` now yields a
  `NeedVOPResponse`, covering banks that do not fill `vop_single_result`.

Two design decisions worth review:

**Termination on data, not on a response code.** The polling loop stops when `vop_id`
or `payment_status_report` appears. Depending on the server release, Atruvia finishes
with either `3090` or `0020`/`0025` — both are reported in #220 — so waiting for one
specific code hangs on the other variant.

**Timeout raises instead of falling through.** Without a result there is nothing to
approve and the order was not executed. Falling through would hand the caller a
`TransactionResponse` carrying only warnings, which reads like success — note that
`_RESPONSE_STATUS_MAPPING` maps `3945` to `WARNING`, not `ERROR`.

## Why inline banks keep working

Each new branch is guarded by a condition that inline banks cannot satisfy:

* polling requires `polling_id` present **and** `vop_id` absent,
* the status-report branch requires `result_code` to be `None`.

For a bank that fills `vop_single_result`, both are false and execution continues into
the unchanged code — including the `0030`/`3955` TAN detection.

That distinction matters. As @payne1979 notes in #220, Sparkassen answer inline, fire
the pushTAN in step 1, and reject a separately sent `HKVPA` with `9010` — *"Any fix
that assumes one of the two will break the other."*

**Measured, not assumed.** A transfer through a Hamburger Sparkasse account after
these changes produced:

```
3091 VOP-Ausführungsauftrag nicht benötigt.
0010 Der Auftrag wurde entgegengenommen.
3076 Starke Kundenauthentifizierung nicht notwendig.
```

with no polling log line at all — the new code was never entered.

## Verification

**Berliner Volksbank (BLZ 10090000, Atruvia).** Polled result on the first attempt:

```
3945 Freigabe ohne VOP-Bestätigung nicht möglich
-> VoP polling attempt 1 (polling_id=b'<uuid>', aufsetzpunkt='staticscrollref', wait=2s)
-> 0025 Keine Namensabweichung.
-> 0020 Ausführungsbestätigung nach Namensabgleich erhalten.
-> 0020 *SEPA-Einzelüberweisung erfolgreich
```

**Commerzbank (BLZ 10080000).** Previously `3945` on every attempt; now:

```
0010 Auftrag entgegengenommen. Ausführung erfolgt vorbehaltlich positiver Disposition.
```

Transfer confirmed in online banking the next morning.

**Hamburger Sparkasse.** Unchanged, see above.

## Scope and limitations

* `pain.002` is passed through untouched, not parsed. Callers receive the `HIVPP` and
  can inspect the report before approving — which is the point of VoP.
* No changes outside the VoP path; `security.py` and `formals.py` are untouched.

## Relation to #211

#211 targets the same area and was a useful starting point — credit to @ArlindNocaj
for the polling idea. This PR differs in three ways: it loops with a timeout instead
of polling once, it selects branches by flow shape rather than by `vop_id` alone
(which keeps the inline path reachable), and it stays inside the VoP flow.
