### PR TITLE
Add timeout for fetching data

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,6 +39,17 @@ of your bank. Logging in with a signature file or chip card is currently not sup
         product_id='Your product ID'  # see above
     )
 
+A single request to the bank times out after 60 seconds, so a bank that accepts the connection and then stops
+answering cannot block your program indefinitely. Pass ``timeout`` in seconds to change that.
+
+.. code-block:: python
+
+    f = FinTS3PinTanClient(
+        *client_args,
+        product_id='Your product ID',
+        timeout=60,
+    )
+
 Since the implementation of PSD2, you will in almost all cases need to be ready to deal with TANs. For a quick start,
 we included a minimal command-line utility to help choose a TAN method:
 

--- a/fints/client.py
+++ b/fints/client.py
@@ -12,7 +12,7 @@ from sepaxml import SepaTransfer
 
 from . import version
 from .camt_parser import camt053_to_dict
-from .connection import FinTSHTTPSConnection
+from .connection import DEFAULT_TIMEOUT, FinTSHTTPSConnection
 from .dialog import FinTSDialog
 from .exceptions import *
 from .formals import (
@@ -1263,10 +1263,11 @@ IMPLEMENTED_HKTAN_VERSIONS = {
 
 class FinTS3PinTanClient(FinTS3Client):
 
-    def __init__(self, bank_identifier, user_id, pin, server, customer_id=None, tan_medium=None, *args, **kwargs):
+    def __init__(self, bank_identifier, user_id, pin, server, customer_id=None, tan_medium=None,
+                 timeout=DEFAULT_TIMEOUT, *args, **kwargs):
         self.pin = Password(pin) if pin is not None else pin
         self._pending_tan = None
-        self.connection = FinTSHTTPSConnection(server)
+        self.connection = FinTSHTTPSConnection(server, timeout=timeout)
         self.allowed_security_functions = []
         self.selected_security_function = None
         self.selected_tan_medium = tan_medium

--- a/fints/connection.py
+++ b/fints/connection.py
@@ -11,6 +11,8 @@ from .types import SegmentSequence
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT = 60
+
 
 def reduce_message_for_log(msg):
     log_msg = msg
@@ -25,8 +27,9 @@ def reduce_message_for_log(msg):
 
 
 class FinTSHTTPSConnection:
-    def __init__(self, url):
+    def __init__(self, url, timeout=DEFAULT_TIMEOUT):
         self.url = url
+        self.timeout = timeout
         self.session = requests.session()
 
     def send(self, msg: FinTSMessage):
@@ -43,6 +46,7 @@ class FinTSHTTPSConnection:
                 headers={
                     'Content-Type': 'text/plain',
                 },
+                timeout=self.timeout,
             )
         except (requests.RequestException, OSError) as e:
             raise FinTSConnectionError("Could not connect to FinTS endpoint: {}".format(e)) from e

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from fints.connection import FinTSHTTPSConnection
+from fints.connection import DEFAULT_TIMEOUT, FinTSHTTPSConnection
 from fints.exceptions import FinTSConnectionError
 
 
@@ -28,3 +28,35 @@ def test_send_wraps_transport_errors():
 
     assert "request timed out" in str(excinfo.value)
     assert isinstance(excinfo.value.__cause__, requests.exceptions.Timeout)
+
+
+def test_send_passes_the_timeout_to_requests():
+    connection = FinTSHTTPSConnection("https://example.invalid/fints", timeout=30)
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured.update(kwargs)
+        raise requests.exceptions.Timeout("request timed out")
+
+    connection.session.post = capture
+
+    with pytest.raises(FinTSConnectionError):
+        connection.send(DummyMessage())
+
+    assert captured["timeout"] == 30
+
+
+def test_send_uses_the_default_timeout_when_none_is_given():
+    connection = FinTSHTTPSConnection("https://example.invalid/fints")
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured.update(kwargs)
+        raise requests.exceptions.Timeout("request timed out")
+
+    connection.session.post = capture
+
+    with pytest.raises(FinTSConnectionError):
+        connection.send(DummyMessage())
+
+    assert captured["timeout"] == DEFAULT_TIMEOUT


### PR DESCRIPTION
`requests` waits indefinitely unless a timeout is given, and `FinTSHTTPSConnection` never passed one. A bank that accepts the TCP connection and then stops answering therefore blocks the caller forever.